### PR TITLE
8273138: BidirectionalBinding fails to observe changes of invalid properties

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
@@ -37,6 +37,14 @@ import java.text.Format;
 import java.text.ParseException;
 import java.util.Objects;
 
+/**
+ * @implNote Bidirectional bindings are implemented with InvalidationListeners, which are fired once
+ *           when the changed property was valid, but elided for any future changes until the property
+ *           is again validated by calling its getValue()/get() method.
+ *           Since bidirectional bindings require that we observe all property changes, independent
+ *           of whether the property was validated by user code, we manually validate both properties
+ *           by calling their getter method in all relevant places.
+ */
 public abstract class BidirectionalBinding implements InvalidationListener, WeakListener {
 
     private static void checkParameters(Object property1, Object property2) {
@@ -62,6 +70,7 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                         new BidirectionalBooleanBinding((BooleanProperty) property1, (BooleanProperty) property2)
                 : new TypedGenericBidirectionalBinding<T>(property1, property2);
         property1.setValue(property2.getValue());
+        property1.getValue();
         property1.addListener(binding);
         property2.addListener(binding);
         return binding;
@@ -72,6 +81,7 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
         Objects.requireNonNull(format, "Format cannot be null");
         final var binding = new StringFormatBidirectionalBinding(stringProperty, otherProperty, format);
         stringProperty.setValue(format.format(otherProperty.getValue()));
+        stringProperty.getValue();
         stringProperty.addListener(binding);
         otherProperty.addListener(binding);
         return binding;
@@ -82,6 +92,7 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
         Objects.requireNonNull(converter, "Converter cannot be null");
         final var binding = new StringConverterBidirectionalBinding<>(stringProperty, otherProperty, converter);
         stringProperty.setValue(converter.toString(otherProperty.getValue()));
+        stringProperty.getValue();
         stringProperty.addListener(binding);
         otherProperty.addListener(binding);
         return binding;
@@ -143,6 +154,7 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
         final BidirectionalBinding binding = new TypedNumberBidirectionalBinding<>(property2, property1);
 
         property1.setValue(property2.getValue());
+        property1.getValue();
         property1.addListener(binding);
         property2.addListener(binding);
         return binding;
@@ -154,6 +166,7 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
         final BidirectionalBinding binding = new TypedNumberBidirectionalBinding<>(property1, property2);
 
         property1.setValue((T)property2.getValue());
+        property1.getValue();
         property1.addListener(binding);
         property2.addListener(binding);
         return binding;
@@ -250,18 +263,22 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                         if (property1 == sourceProperty) {
                             boolean newValue = property1.get();
                             property2.set(newValue);
+                            property2.get();
                             oldValue = newValue;
                         } else {
                             boolean newValue = property2.get();
                             property1.set(newValue);
+                            property1.get();
                             oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
                                 property1.set(oldValue);
+                                property1.get();
                             } else {
                                 property2.set(oldValue);
+                                property2.get();
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -323,18 +340,22 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                         if (property1 == sourceProperty) {
                             double newValue = property1.get();
                             property2.set(newValue);
+                            property2.get();
                             oldValue = newValue;
                         } else {
                             double newValue = property2.get();
                             property1.set(newValue);
+                            property1.get();
                             oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
                                 property1.set(oldValue);
+                                property1.get();
                             } else {
                                 property2.set(oldValue);
+                                property2.get();
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -396,18 +417,22 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                         if (property1 == sourceProperty) {
                             float newValue = property1.get();
                             property2.set(newValue);
+                            property2.get();
                             oldValue = newValue;
                         } else {
                             float newValue = property2.get();
                             property1.set(newValue);
+                            property1.get();
                             oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
                                 property1.set(oldValue);
+                                property1.get();
                             } else {
                                 property2.set(oldValue);
+                                property2.get();
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -469,18 +494,22 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                         if (property1 == sourceProperty) {
                             int newValue = property1.get();
                             property2.set(newValue);
+                            property2.get();
                             oldValue = newValue;
                         } else {
                             int newValue = property2.get();
                             property1.set(newValue);
+                            property1.get();
                             oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
                                 property1.set(oldValue);
+                                property1.get();
                             } else {
                                 property2.set(oldValue);
+                                property2.get();
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -542,18 +571,22 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                         if (property1 == sourceProperty) {
                             long newValue = property1.get();
                             property2.set(newValue);
+                            property2.get();
                             oldValue = newValue;
                         } else {
                             long newValue = property2.get();
                             property1.set(newValue);
+                            property1.get();
                             oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
                                 property1.set(oldValue);
+                                property1.get();
                             } else {
                                 property2.set(oldValue);
+                                property2.get();
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -615,18 +648,22 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                         if (property1 == sourceProperty) {
                             T newValue = property1.getValue();
                             property2.setValue(newValue);
+                            property2.getValue();
                             oldValue = newValue;
                         } else {
                             T newValue = property2.getValue();
                             property1.setValue(newValue);
+                            property1.getValue();
                             oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
                                 property1.setValue(oldValue);
+                                property1.getValue();
                             } else {
                                 property2.setValue(oldValue);
+                                property2.getValue();
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -688,18 +725,22 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                         if (property1 == sourceProperty) {
                             T newValue = property1.getValue();
                             property2.setValue(newValue);
+                            property2.getValue();
                             oldValue = newValue;
                         } else {
                             T newValue = (T)property2.getValue();
                             property1.setValue(newValue);
+                            property1.getValue();
                             oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
                                 property1.setValue((T)oldValue);
+                                property1.getValue();
                             } else {
                                 property2.setValue(oldValue);
+                                property2.getValue();
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -789,16 +830,20 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                         if (property1 == observable) {
                             try {
                                 property2.setValue(fromString(property1.getValue()));
+                                property2.getValue();
                             } catch (Exception e) {
                                 Logging.getLogger().warning("Exception while parsing String in bidirectional binding", e);
                                 property2.setValue(null);
+                                property2.getValue();
                             }
                         } else {
                             try {
                                 property1.setValue(toString(property2.getValue()));
+                                property1.getValue();
                             } catch (Exception e) {
                                 Logging.getLogger().warning("Exception while converting Object to String in bidirectional binding", e);
                                 property1.setValue("");
+                                property1.getValue();
                             }
                         }
                     } finally {

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingTest.java
@@ -301,6 +301,15 @@ public class BidirectionalBindingTest<T> {
         assertEquals(v[1], op2.getValue());
     }
 
+    @Test
+    public void testSetValueWithoutIntermediateValidation() {
+        BidirectionalBinding.bind(op1, op2);
+        op1.setValue(v[0]);
+        op2.setValue(v[1]);
+        assertEquals(v[1], op1.getValue());
+        assertEquals(v[1], op2.getValue());
+    }
+
     @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         final Boolean[] booleanData = new Boolean[] {true, false, true, false};


### PR DESCRIPTION
Clean backport to `jfx17u`. This has been tested along with other pending fixes in the `test-kcr-17.0.1` branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273138](https://bugs.openjdk.java.net/browse/JDK-8273138): BidirectionalBinding fails to observe changes of invalid properties


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/5.diff">https://git.openjdk.java.net/jfx17u/pull/5.diff</a>

</details>
