### PR TITLE
8273324: IllegalArgumentException: fromIndex(0) > toIndex(-1) after clear and select TableCell

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
@@ -86,9 +86,15 @@ class ControlUtils {
             private int from = -1;
 
             {
-                int midIndex = -Collections.binarySearch(removed, retainedRow, rowComparator) - 1;
-                firstRemovedRange = removed.subList(0, midIndex);
-                secondRemovedRange = removed.subList(midIndex, removedSize);
+                int insertionPoint = Collections.binarySearch(removed, retainedRow, rowComparator);
+                if (insertionPoint >= 0) {
+                    firstRemovedRange = removed;
+                    secondRemovedRange = Collections.emptyList();
+                } else {
+                    int midIndex = -insertionPoint - 1;
+                    firstRemovedRange = removed.subList(0, midIndex);
+                    secondRemovedRange = removed.subList(midIndex, removedSize);
+                }
             }
 
             @Override public int getFrom() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -352,6 +352,50 @@ public class TableViewTest {
         assertEquals("Item 2", fm.getFocusedItem());
     }
 
+    @Test
+    public void ensureRowRemainsSelectedWhenSelectingCellInSameRow() {
+        class Person {
+            final String firstName, lastName;
+            Person(String firstName, String lastName) {
+                this.firstName = firstName;
+                this.lastName = lastName;
+            }
+            public String getFirstName() { return firstName; }
+            public String getLastName() { return lastName; }
+        }
+
+        var tableView = new TableView<Person>();
+        tableView.getSelectionModel().setCellSelectionEnabled(true);
+        tableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
+        var col1 = new TableColumn<Person, String>();
+        col1.setCellValueFactory(new PropertyValueFactory<>("firstName"));
+        var col2 = new TableColumn<Person, String>();
+        col2.setCellValueFactory(new PropertyValueFactory<>("lastName"));
+        tableView.getColumns().addAll(List.of(col1, col2));
+
+        var ab = new Person("a", "b");
+        tableView.getItems().add(ab);
+        var cd = new Person("c", "d");
+        tableView.getItems().add(cd);
+
+        var selectionModel = tableView.getSelectionModel();
+        selectionModel.select(0);
+        selectionModel.clearAndSelect(0, col1);
+
+        // The following asserts should work once JDK-8273336 is fixed:
+        //
+        // assertEquals(1, selectionModel.getSelectedIndices().size());
+        // assertEquals(0, (int)selectionModel.getSelectedIndices().get(0));
+
+        selectionModel.clearSelection();
+        selectionModel.selectRange(0, col1, 1, col2);
+        selectionModel.clearAndSelect(1, col2);
+
+        // assertEquals(1, selectionModel.getSelectedIndices().size());
+        // assertEquals(1, (int)selectionModel.getSelectedIndices().get(0));
+    }
+
     /*********************************************************************
      * Tests for columns                                                 *
      ********************************************************************/


### PR DESCRIPTION
Clean backport to `jfx17u`. This has been tested along with other pending fixes in the `test-kcr-17.0.1` branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273324](https://bugs.openjdk.java.net/browse/JDK-8273324): IllegalArgumentException: fromIndex(0) > toIndex(-1) after clear and select TableCell


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/6.diff">https://git.openjdk.java.net/jfx17u/pull/6.diff</a>

</details>
