### PR TITLE
8273754: Re-introduce Automatic-Module-Name in empty jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4786,6 +4786,11 @@ compileTargets { t ->
         def modularEmptyPublicationJarTask = project.task("moduleEmptyPublicationJar${t.capital}", type: Jar) {
             destinationDirectory = file("${dstModularJarDir}")
             archiveFileName = modularEmptyPublicationJarName
+            manifest {
+                attributes(
+                        'Automatic-Module-Name':"${moduleName}Empty"
+                )
+            }
         }
 
         def modularPublicationJarName = "${moduleName}-${t.name}.jar"


### PR DESCRIPTION
Clean backport of JDK-8273754 which also appears in hotfix build 17.0.0.1

Reviewed-by: kcr, jvos

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273754](https://bugs.openjdk.java.net/browse/JDK-8273754): Re-introduce Automatic-Module-Name in empty jars


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/11.diff">https://git.openjdk.java.net/jfx17u/pull/11.diff</a>

</details>
