### PR TITLE
8269374: Menu inoperable after setting stage to second monitor

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinView.java
@@ -91,5 +91,14 @@ final class WinView extends View {
     @Override native protected boolean _enterFullscreen(long ptr, boolean animate, boolean keepRatio, boolean hideCursor);
     @Override native protected void _exitFullscreen(long ptr, boolean animate);
 
+    @Override
+    protected void notifyResize(int width, int height) {
+        super.notifyResize(width, height);
+
+        // After resizing, do a move notification to force the view relocation.
+        // When moving to a screen with different DPI settings, its location needs
+        // to be recalculated.
+        updateLocation();
+    }
 }
 


### PR DESCRIPTION
Clean backport of JDK-8269374 (already in 11.0.13)

Reviewed-by: kcr, arapte

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269374](https://bugs.openjdk.java.net/browse/JDK-8269374): Menu inoperable after setting stage to second monitor


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/12.diff">https://git.openjdk.java.net/jfx17u/pull/12.diff</a>

</details>
