### PR TITLE
8275837: Change JavaFX release version in jfx17u to 17.0.2

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -41,7 +41,7 @@ jfx.release.suffix=-ea
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
 jfx.release.major.version=17
 jfx.release.minor.version=0
-jfx.release.security.version=1
+jfx.release.security.version=2
 jfx.release.patch.version=0
 
 # Note: The release version is now calculated in build.gradle as the


### PR DESCRIPTION
Bump release version in `jfx17u` repo to 17.0.2 for the start of a new release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275837](https://bugs.openjdk.java.net/browse/JDK-8275837): Change JavaFX release version in jfx17u to 17.0.2


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/15.diff">https://git.openjdk.java.net/jfx17u/pull/15.diff</a>

</details>
