### PR TITLE
8275723: Crash on macOS 12 in GlassRunnable::dealloc

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -98,28 +98,19 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     {
         assert(pthread_main_np() == 1);
         JNIEnv *env = jEnv;
-        if (env != NULL)
+        if (env != NULL && self->jRunnable != NULL)
         {
             (*env)->CallVoidMethod(env, self->jRunnable, jRunnableRun);
             GLASS_CHECK_EXCEPTION(env);
+
+            (*env)->DeleteGlobalRef(env, self->jRunnable);
         }
+
+        self->jRunnable = NULL;
 
         [self release];
     }
     [pool drain];
-}
-
-- (void)dealloc
-{
-    assert(pthread_main_np() == 1);
-    JNIEnv *env = jEnv;
-    if (env != NULL)
-    {
-        (*env)->DeleteGlobalRef(env, self->jRunnable);
-    }
-    self->jRunnable = NULL;
-
-    [super dealloc];
 }
 
 @end


### PR DESCRIPTION
Clean backport. Tested on macOS 10.15.7 and 12.0.1-beta.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275723](https://bugs.openjdk.java.net/browse/JDK-8275723): Crash on macOS 12 in GlassRunnable::dealloc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/18.diff">https://git.openjdk.java.net/jfx17u/pull/18.diff</a>

</details>
