### PR TITLE
8276490: Incorrect path for duplicate x and y values, when path falls outside axis bound

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/AreaChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/AreaChart.java
@@ -34,6 +34,7 @@ import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.beans.NamedArg;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.collections.FXCollections;
@@ -53,7 +54,6 @@ import javafx.util.Duration;
 
 import com.sun.javafx.charts.Legend.LegendItem;
 import javafx.css.converter.BooleanConverter;
-import javafx.beans.property.BooleanProperty;
 import javafx.css.CssMetaData;
 import javafx.css.Styleable;
 import javafx.css.StyleableBooleanProperty;
@@ -467,8 +467,8 @@ public class AreaChart<X,Y> extends XYChart<X,Y> {
             if (x < dataXMin || y < dataYMin) {
                 if (prevDataPoint == null) {
                     prevDataPoint = new LineTo(x, y);
-                } else if ((sortX && prevDataPoint.getX() <= x) ||
-                           (sortY && prevDataPoint.getY() <= y))
+                } else if ((sortX && prevDataPoint.getX() < x) ||
+                           (sortY && prevDataPoint.getY() < y))
                 {
                     prevDataPoint.setX(x);
                     prevDataPoint.setY(y);
@@ -478,8 +478,8 @@ public class AreaChart<X,Y> extends XYChart<X,Y> {
             } else {
                 if (nextDataPoint == null) {
                     nextDataPoint = new LineTo(x, y);
-                } else if ((sortX && x <= nextDataPoint.getX()) ||
-                           (sortY && y <= nextDataPoint.getY()))
+                } else if ((sortX && x < nextDataPoint.getX()) ||
+                           (sortY && y < nextDataPoint.getY()))
                 {
                     nextDataPoint.setX(x);
                     nextDataPoint.setY(y);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/AreaChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/AreaChartTest.java
@@ -27,6 +27,7 @@ package test.javafx.scene.chart;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.geometry.Point2D;
 import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.chart.AreaChart;
@@ -36,18 +37,26 @@ import javafx.scene.chart.Chart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
 import javafx.scene.chart.XYChartShim;
+import javafx.scene.shape.LineTo;
 import javafx.scene.shape.Path;
+
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+
+import javafx.scene.shape.PathElement;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class AreaChartTest extends XYChartTestBase {
     AreaChart<Number,Number> ac;
-    final XYChart.Series<Number, Number> series1 = new XYChart.Series<Number, Number>();
+    final XYChart.Series<Number, Number> series1 = new XYChart.Series<>();
     boolean useCategoryAxis = false;
     final String[] countries = {"USA", "Italy", "France", "China", "India"};
     protected Chart createChart() {
-        final NumberAxis yAxis = new NumberAxis();
+        final NumberAxis yAxis = new NumberAxis(0, 30, 2);
         ObservableList<XYChart.Data> data = FXCollections.observableArrayList();
         Axis xAxis;
         if (useCategoryAxis) {
@@ -60,7 +69,7 @@ public class AreaChartTest extends XYChartTestBase {
         series1.getData().add(new XYChart.Data(countries[3], 15d));
         series1.getData().add(new XYChart.Data(countries[4], 10d));
         } else {
-            xAxis = new NumberAxis();
+            xAxis = new NumberAxis(0, 90, 10);
             ac = new AreaChart<Number,Number>(xAxis,yAxis);
             // add starting data
         series1.getData().add(new XYChart.Data(10d, 10d));
@@ -151,4 +160,202 @@ public class AreaChartTest extends XYChartTestBase {
          pulse();
          assertEquals(5, countSymbols(ac, "chart-area-symbol"));
      }
+
+    @Test public void testPathInsideXAndInsideYBounds() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(85d, 15d)); // upper bound is 90,30
+        ac.getData().addAll(series1);
+        pulse();
+
+        assertArrayEquals(convertSeriesDataToPoint2D(series1).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXBoundsWithDuplicateXAndHigherY() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(100d, 20d)); // upper bound is 90
+        series1.getData().add(new XYChart.Data<>(100d, 50d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(100d, 20d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXBoundsWithDuplicateXAndLowerY() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(100d, 20d)); // upper bound is 90
+        series1.getData().add(new XYChart.Data<>(100d, 15d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(100d, 20d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideYBoundsWithDuplicateYAndLowerX() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(85d, 40d));
+        series1.getData().add(new XYChart.Data<>(70d, 40d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                // Sorting policy in AreaChart is defaulted to X_AXIS. See AreaChart#makePaths
+                new XYChart.Data<>(70d, 40d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(85d, 40d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideYBoundsWithDuplicateYAndHigherX() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(70d, 32d)); // upper bound is 30
+        series1.getData().add(new XYChart.Data<>(85d, 32d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(70d, 32d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(85d, 32d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateXAndHigherY() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(95d, 35d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(95d, 40d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(95d, 35d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateXAndLowerY() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(95d, 40d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(95d, 35d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(95d, 40d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateYAndHigherX() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(95d, 32d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(100d, 32d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(95d, 32d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateYAndLowerX() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(100d, 40d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(95d, 40d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(95d, 40d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    private List<Point2D> convertSeriesDataToPoint2D(XYChart.Series<Number, Number> series) {
+        return series.getData().stream()
+                .map(data -> new Point2D(data.getXValue().doubleValue(), data.getYValue().doubleValue()))
+                .collect(Collectors.toList());
+    }
+
+    private List<Point2D> findDataPointsFromPathLine(AreaChart<Number, Number> areaChart) {
+        final NumberAxis xAxis = (NumberAxis) areaChart.getXAxis();
+        final NumberAxis yAxis = (NumberAxis) areaChart.getYAxis();
+
+        final ObservableList<Node> children = ((Group) areaChart.getData().get(0).getNode()).getChildren();
+        Path fillPath = (Path) children.get(0);
+        ObservableList<PathElement> fillElements = fillPath.getElements();
+
+        List<Point2D> data = fillElements.stream()
+                .filter(pathElement -> pathElement instanceof LineTo)
+                .map(pathElement -> (LineTo) pathElement)
+                .map(lineTo -> new Point2D(
+                        xAxis.getValueForDisplay(lineTo.getX()).doubleValue(),
+                        yAxis.getValueForDisplay(lineTo.getY()).doubleValue())
+                )
+                .collect(Collectors.toList());
+        // Due to fillPath, one additional LineTo element is added to close the loop
+        return data.subList(0, data.size() - 1);
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/LineChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/LineChartTest.java
@@ -26,16 +26,24 @@
 package test.javafx.scene.chart;
 
 import javafx.collections.ObservableList;
+import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.chart.Chart;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
 import javafx.scene.chart.XYChartShim;
+import javafx.scene.shape.LineTo;
 import javafx.scene.shape.Path;
-import static org.junit.Assert.assertEquals;
+import javafx.scene.shape.PathElement;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class LineChartTest extends XYChartTestBase {
 
@@ -43,8 +51,8 @@ public class LineChartTest extends XYChartTestBase {
     final XYChart.Series<Number, Number> series1 = new XYChart.Series<Number, Number>();
 
     @Override protected Chart createChart() {
-        final NumberAxis xAxis = new NumberAxis();
-        final NumberAxis yAxis = new NumberAxis();
+        final NumberAxis xAxis = new NumberAxis(0, 90, 10);
+        final NumberAxis yAxis = new NumberAxis(0, 30, 2);;
         lineChart = new LineChart<Number,Number>(xAxis,yAxis);
         xAxis.setLabel("X Axis");
         yAxis.setLabel("Y Axis");
@@ -158,5 +166,370 @@ public class LineChartTest extends XYChartTestBase {
         //lineChart.setCreateSymbols(false);
         int nodesPerSeries = 4; // 3 symbols + 1 path
         checkSeriesRemoveAnimatedStyleClasses(lineChart, nodesPerSeries, 900);
+    }
+
+    @Test public void testPathInsideXAndInsideYBounds() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(85d, 15d)); // upper bound is 90, 30
+        lineChart.getData().addAll(series1);
+        pulse();
+
+        assertArrayEquals(convertSeriesDataToPoint2D(series1).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXBoundsWithDuplicateXAndHigherY() {
+        startApp();
+        series1.getData().add(new XYChart.Data(100d, 20d)); // upper bound is 90
+        series1.getData().add(new XYChart.Data(100d, 50d));
+        lineChart.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(100d, 20d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXBoundsWithDuplicateXAndLowerY() {
+        startApp();
+        series1.getData().add(new XYChart.Data(100d, 20d)); // upper bound is 90
+        series1.getData().add(new XYChart.Data(100d, 15d));
+        lineChart.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(100d, 20d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideYBoundsWithDuplicateYAndHigherX() {
+        startApp();
+        series1.getData().add(new XYChart.Data(80d, 32d)); // upper bound is 30
+        series1.getData().add(new XYChart.Data(90d, 32d));
+        lineChart.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(80d, 32d),
+                new XYChart.Data<>(90d, 32d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideYBoundsWithDuplicateYAndLowerX() {
+        startApp();
+        series1.getData().add(new XYChart.Data(85d, 40d)); // upper bound is 30
+        series1.getData().add(new XYChart.Data(90d, 40d));
+        lineChart.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(85d, 40d),
+                new XYChart.Data<>(90d, 40d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateXAndHigherY() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(95d, 35d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(95d, 40d));
+        lineChart.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(95d, 35d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateXAndLowerY() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(95d, 40d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(95d, 35d));
+        lineChart.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(95d, 40d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateYAndHigherX() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(95d, 32d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(100d, 32d));
+        lineChart.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(95d, 32d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateYAndLowerX() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(100d, 40d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(95d, 40d));
+        lineChart.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(95d, 40d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXBoundsWithDuplicateXAndHigherYWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data(100d, 20d)); // upper bound is 90
+        series1.getData().add(new XYChart.Data(100d, 50d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(100d, 50d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(100d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXBoundsWithDuplicateXAndLowerYWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data(100d, 20d)); // upper bound is 90
+        series1.getData().add(new XYChart.Data(100d, 15d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(100d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(100d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideYBoundsWithDuplicateYAndHigherXWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data(80d, 32d)); // upper bound is 30
+        series1.getData().add(new XYChart.Data(90d, 32d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(80d, 32d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideYBoundsWithDuplicateYAndLowerXWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data(80d, 40d)); // upper bound is 30
+        series1.getData().add(new XYChart.Data(70d, 40d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(80d, 40d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateXAndHigherYWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(95d, 35d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(95d, 40d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(95d, 35d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateXAndLowerYWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(95d, 40d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(95d, 35d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(95d, 35d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateYAndHigherXWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(95d, 32d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(100d, 32d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(95d, 32d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYBoundsWithDuplicateYAndLowerXWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(100d, 40d)); // upper bound is 90,30
+        series1.getData().add(new XYChart.Data<>(95d, 40d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(100d, 40d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    private List<Point2D> convertSeriesDataToPoint2D(XYChart.Series<Number, Number> series) {
+        return series.getData().stream()
+                .map(data -> new Point2D(data.getXValue().doubleValue(), data.getYValue().doubleValue()))
+                .collect(Collectors.toList());
+    }
+
+    private List<Point2D> findDataPointsFromPathLine(LineChart<Number, Number> lineChart) {
+        final NumberAxis xAxis = (NumberAxis) lineChart.getXAxis();
+        final NumberAxis yAxis = (NumberAxis) lineChart.getYAxis();
+
+        Path fillPath = (Path) lineChart.getData().get(0).getNode();
+        ObservableList<PathElement> fillElements = fillPath.getElements();
+
+        List<Point2D> data = fillElements.stream()
+                .filter(pathElement -> pathElement instanceof LineTo)
+                .map(pathElement -> (LineTo) pathElement)
+                .map(lineTo -> new Point2D(
+                        xAxis.getValueForDisplay(lineTo.getX()).doubleValue(),
+                        yAxis.getValueForDisplay(lineTo.getY()).doubleValue())
+                )
+                .collect(Collectors.toList());
+        return data.subList(0, data.size());
     }
 }


### PR DESCRIPTION
backport (18->11) for 8276490: Incorrect path for duplicate x and y values, when path falls outside axis bound

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276490](https://bugs.openjdk.java.net/browse/JDK-8276490): Incorrect path for duplicate x and y values, when path falls outside axis bound


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/25.diff">https://git.openjdk.java.net/jfx17u/pull/25.diff</a>

</details>
