### PR TITLE
8280172: Create release notes for JavaFX 17.0.2

### DIFF
--- a/doc-files/release-notes-17.0.2.md
+++ b/doc-files/release-notes-17.0.2.md
@@ -8,26 +8,24 @@ As of JDK 11 the JavaFX modules are delivered separately from the JDK. These rel
 
 JavaFX 17.0.2 requires JDK 11 or later.
 
-List of Task
-------------
+## List of Task
 
-| Issue Key                                                       | Summary                                                 | Subcomponent |
-| --------------------------------------------------------------- | ------------------------------------------------------- | ------------ |
-| [JDK-8272638](https://bugs.openjdk.java.net/browse/JDK-8272638) | Update copyright header for files modified in 2021      | other        |
-| [JDK-8274413](https://bugs.openjdk.java.net/browse/JDK-8274413) | FX: Update copyright year in docs, readme files to 2022 | other        |
-| [JDK-8279396](https://bugs.openjdk.java.net/browse/JDK-8279396) | Define version in .jcheck/conf                          | other        |
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8272638](https://bugs.openjdk.java.net/browse/JDK-8272638)|Update copyright header for files modified in 2021|other
+[JDK-8274413](https://bugs.openjdk.java.net/browse/JDK-8274413)|FX: Update copyright year in docs, readme files to 2022|other
+[JDK-8279396](https://bugs.openjdk.java.net/browse/JDK-8279396)|Define version in .jcheck/conf|other
 
-List of Fixed Bugs
-------------------
+## List of Fixed Bugs
 
-| Issue Key                                                       | Summary                                                                         | Subcomponent   |
-| --------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------- |
-| [JDK-8274022](https://bugs.openjdk.java.net/browse/JDK-8274022) | Additional Memory Leak in ControlAcceleratorSupport                             | controls       |
-| [JDK-8274854](https://bugs.openjdk.java.net/browse/JDK-8274854) | Mnemonics for menu containing numeric text not working                          | controls       |
-| [JDK-8276490](https://bugs.openjdk.java.net/browse/JDK-8276490) | Incorrect path for duplicate x and y values, when path falls outside axis bound | graphics       |
-| [JDK-8275138](https://bugs.openjdk.java.net/browse/JDK-8275138) | WebView: UserAgent string is empty for first request                            | web            |
-| [JDK-8276847](https://bugs.openjdk.java.net/browse/JDK-8276847) | JSException: ReferenceError: Can't find variable: IntersectionObserver          | web            |
-| [JDK-8277133](https://bugs.openjdk.java.net/browse/JDK-8277133) | Dragboard contents retrieved all over again during a DND process on WebView     | web            |
-| [JDK-8160597](https://bugs.openjdk.java.net/browse/JDK-8160597) | IllegalArgumentException when we initiate drag on Image                         | window-toolkit |
-| [JDK-8274929](https://bugs.openjdk.java.net/browse/JDK-8274929) | Crash while reading specific clipboard content                                  | window-toolkit |
-| [JDK-8275723](https://bugs.openjdk.java.net/browse/JDK-8275723) | Crash on macOS 12 in GlassRunnable::dealloc                                     | window-toolkit |
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8274022](https://bugs.openjdk.java.net/browse/JDK-8274022)|Additional Memory Leak in ControlAcceleratorSupport|controls
+[JDK-8274854](https://bugs.openjdk.java.net/browse/JDK-8274854)|Mnemonics for menu containing numeric text not working|controls
+[JDK-8276490](https://bugs.openjdk.java.net/browse/JDK-8276490)|Incorrect path for duplicate x and y values, when path falls outside axis bound|graphics
+[JDK-8275138](https://bugs.openjdk.java.net/browse/JDK-8275138)|WebView: UserAgent string is empty for first request|web
+[JDK-8276847](https://bugs.openjdk.java.net/browse/JDK-8276847)|JSException: ReferenceError: Can't find variable: IntersectionObserver|web
+[JDK-8277133](https://bugs.openjdk.java.net/browse/JDK-8277133)|Dragboard contents retrieved all over again during a DND process on WebView|web
+[JDK-8160597](https://bugs.openjdk.java.net/browse/JDK-8160597)|IllegalArgumentException when we initiate drag on Image|window-toolkit
+[JDK-8274929](https://bugs.openjdk.java.net/browse/JDK-8274929)|Crash while reading specific clipboard content|window-toolkit
+[JDK-8275723](https://bugs.openjdk.java.net/browse/JDK-8275723)|Crash on macOS 12 in GlassRunnable::dealloc|window-toolkit

--- a/doc-files/release-notes-17.0.2.md
+++ b/doc-files/release-notes-17.0.2.md
@@ -8,14 +8,6 @@ As of JDK 11 the JavaFX modules are delivered separately from the JDK. These rel
 
 JavaFX 17.0.2 requires JDK 11 or later.
 
-## List of Task
-
-Issue key|Summary|Subcomponent
----------|-------|------------
-[JDK-8272638](https://bugs.openjdk.java.net/browse/JDK-8272638)|Update copyright header for files modified in 2021|other
-[JDK-8274413](https://bugs.openjdk.java.net/browse/JDK-8274413)|FX: Update copyright year in docs, readme files to 2022|other
-[JDK-8279396](https://bugs.openjdk.java.net/browse/JDK-8279396)|Define version in .jcheck/conf|other
-
 ## List of Fixed Bugs
 
 Issue key|Summary|Subcomponent

--- a/doc-files/release-notes-17.0.2.md
+++ b/doc-files/release-notes-17.0.2.md
@@ -1,0 +1,33 @@
+# Release Notes for JavaFX 17.0.2
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+As of JDK 11 the JavaFX modules are delivered separately from the JDK. These release notes cover the standalone JavaFX 17.0.2 release. As such, they complement the [JavaFX 17 Release Notes](https://github.com/openjdk/jfx/blob/jfx17/doc-files/release-notes-17.md).
+
+JavaFX 17.0.2 requires JDK 11 or later.
+
+List of Task
+------------
+
+| Issue Key                                                       | Summary                                                 | Subcomponent |
+| --------------------------------------------------------------- | ------------------------------------------------------- | ------------ |
+| [JDK-8272638](https://bugs.openjdk.java.net/browse/JDK-8272638) | Update copyright header for files modified in 2021      | other        |
+| [JDK-8274413](https://bugs.openjdk.java.net/browse/JDK-8274413) | FX: Update copyright year in docs, readme files to 2022 | other        |
+| [JDK-8279396](https://bugs.openjdk.java.net/browse/JDK-8279396) | Define version in .jcheck/conf                          | other        |
+
+List of Fixed Bugs
+------------------
+
+| Issue Key                                                       | Summary                                                                         | Subcomponent   |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------- |
+| [JDK-8274022](https://bugs.openjdk.java.net/browse/JDK-8274022) | Additional Memory Leak in ControlAcceleratorSupport                             | controls       |
+| [JDK-8274854](https://bugs.openjdk.java.net/browse/JDK-8274854) | Mnemonics for menu containing numeric text not working                          | controls       |
+| [JDK-8276490](https://bugs.openjdk.java.net/browse/JDK-8276490) | Incorrect path for duplicate x and y values, when path falls outside axis bound | graphics       |
+| [JDK-8275138](https://bugs.openjdk.java.net/browse/JDK-8275138) | WebView: UserAgent string is empty for first request                            | web            |
+| [JDK-8276847](https://bugs.openjdk.java.net/browse/JDK-8276847) | JSException: ReferenceError: Can't find variable: IntersectionObserver          | web            |
+| [JDK-8277133](https://bugs.openjdk.java.net/browse/JDK-8277133) | Dragboard contents retrieved all over again during a DND process on WebView     | web            |
+| [JDK-8160597](https://bugs.openjdk.java.net/browse/JDK-8160597) | IllegalArgumentException when we initiate drag on Image                         | window-toolkit |
+| [JDK-8274929](https://bugs.openjdk.java.net/browse/JDK-8274929) | Crash while reading specific clipboard content                                  | window-toolkit |
+| [JDK-8275723](https://bugs.openjdk.java.net/browse/JDK-8275723) | Crash on macOS 12 in GlassRunnable::dealloc                                     | window-toolkit |

--- a/doc-files/release-notes-17.0.2.md
+++ b/doc-files/release-notes-17.0.2.md
@@ -29,3 +29,9 @@ Issue key|Summary|Subcomponent
 [JDK-8160597](https://bugs.openjdk.java.net/browse/JDK-8160597)|IllegalArgumentException when we initiate drag on Image|window-toolkit
 [JDK-8274929](https://bugs.openjdk.java.net/browse/JDK-8274929)|Crash while reading specific clipboard content|window-toolkit
 [JDK-8275723](https://bugs.openjdk.java.net/browse/JDK-8275723)|Crash on macOS 12 in GlassRunnable::dealloc|window-toolkit
+
+## List of Security fixes
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+JDK-8272546 (not public) | Better TrueType font loading | graphics


### PR DESCRIPTION
Release Notes for 17.0.2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280172](https://bugs.openjdk.java.net/browse/JDK-8280172): Create release notes for JavaFX 17.0.2


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/28.diff">https://git.openjdk.java.net/jfx17u/pull/28.diff</a>

</details>
