### PR TITLE
8255940: localStorage is null after window.close()

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/modules/javafx.web/src/main/native/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -1579,7 +1579,7 @@ NeedsSiteSpecificQuirks:
     WebKit:
       default: true
     WebCore:
-      default: false
+      default: true
 
 NeedsStorageAccessFromFileURLsQuirk:
   type: bool

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
@@ -847,19 +847,28 @@ ExceptionOr<Storage*> DOMWindow::localStorage()
     if (!document->securityOrigin().canAccessLocalStorage(nullptr))
         return Exception { SecurityError };
 
+#if PLATFORM(JAVA)
+     if (m_localStorage)
+         return m_localStorage.get();
+#endif
+
     auto* page = document->page();
+#if !PLATFORM(JAVA)
     // FIXME: We should consider supporting access/modification to local storage
     // after calling window.close(). See <https://bugs.webkit.org/show_bug.cgi?id=135330>.
     if (!page || !page->isClosing()) {
         if (m_localStorage)
             return m_localStorage.get();
     }
+#endif
 
     if (!page)
         return nullptr;
 
+#if !PLATFORM(JAVA)
     if (page->isClosing())
         return nullptr;
+#endif
 
     if (!page->settings().localStorageEnabled())
         return nullptr;

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LocalStorageTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LocalStorageTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import javafx.scene.web.WebView;
+import javafx.scene.web.WebEngine;
+
+
+public class LocalStorageTest extends TestBase {
+
+    private static final File LOCAL_STORAGE_DIR = new File("LocalStorageDir");
+
+    private static void deleteRecursively(File file) throws IOException {
+        if (file.isDirectory()) {
+            for (File f : file.listFiles()) {
+                deleteRecursively(f);
+            }
+        }
+        if (!file.delete()) {
+            // If WebKit takes time to close the file, better
+            // delete it during VM shutdown.
+            file.deleteOnExit();
+        }
+    }
+
+    private WebEngine createWebEngine() {
+        return submit(() -> new WebEngine());
+    }
+
+    /* test localstorage instance */
+    void checkLocalStorageAfterWindowClose(WebEngine webEngine) {
+        load(new File("src/test/resources/test/html/localstorage.html"));
+        submit(() -> {
+            assertNotNull(webEngine.executeScript("localStorage;"));
+            getEngine().executeScript("window.close();");
+            assertNotNull(webEngine.executeScript("localStorage;"));
+        });
+    }
+
+    @AfterClass
+    public static void afterClass() throws IOException {
+        deleteRecursively(LOCAL_STORAGE_DIR);
+    }
+
+    @Test
+    public void testLocalStorage() throws Exception {
+        final WebEngine webEngine = getEngine();
+        webEngine.setJavaScriptEnabled(true);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
+        checkLocalStorageAfterWindowClose(webEngine);
+    }
+
+    /* test localstorage set data before window.close and check data after window.close */
+    @Test
+    public void testLocalStorageData() {
+        final WebEngine webEngine = getEngine();
+        webEngine.setJavaScriptEnabled(true);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
+        load(new File("src/test/resources/test/html/localstorage.html"));
+        submit(() -> {
+            WebView view = getView();
+            view.getEngine().executeScript("test_local_storage_set();"); // set data
+            getEngine().executeScript("window.close();");
+            //get data
+            String s = (String) view.getEngine().executeScript("document.getElementById('key').innerText;");
+            assertEquals("1001", s);
+        });
+    }
+
+    @Test
+    public void testLocalStorageSet() {
+        final WebEngine webEngine = getEngine();
+        webEngine.setJavaScriptEnabled(true);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
+        load(new File("src/test/resources/test/html/localstorage.html"));
+        submit(() -> {
+            WebView view = getView();
+            view.getEngine().executeScript("test_local_storage_set();");
+            String s = (String) view.getEngine().executeScript("document.getElementById('key').innerText;");
+            assertEquals("1001", s);
+        });
+    }
+
+    @Test
+    public void testLocalStoargeClear() {
+        final WebEngine webEngine = getEngine();
+        webEngine.setJavaScriptEnabled(true);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
+        load(new File("src/test/resources/test/html/localstorage.html"));
+        submit(() -> {
+            WebView view = getView();
+            view.getEngine().executeScript("test_local_storage_set();"); // set data
+            view.getEngine().executeScript("delete_items();");
+            String s = (String) view.getEngine().executeScript("document.getElementById('key').innerText;");
+            boolean res = (s == null || s.length() == 0);
+            assertTrue(res);
+        });
+    }
+}

--- a/modules/javafx.web/src/test/resources/test/html/localstorage.html
+++ b/modules/javafx.web/src/test/resources/test/html/localstorage.html
@@ -1,0 +1,27 @@
+<html>
+<body>
+
+<h2>The localStorage Property Test</h2>
+
+<p id="key"></p>
+
+<script>
+
+ // Test set and get Items API
+ function test_local_storage_set() {
+   // Set Item
+   localStorage.setItem("key", "1001");
+   // getItem
+   document.getElementById("key").innerHTML = localStorage.getItem("key");
+ }
+
+ // test clear() API
+ function delete_items() {
+  localStorage.clear();
+  document.getElementById("key").innerHTML = localStorage.getItem("key");
+ }
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Reviewed-by: kcr, arapte

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255940](https://bugs.openjdk.java.net/browse/JDK-8255940): localStorage is null after window.close()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/45.diff">https://git.openjdk.java.net/jfx17u/pull/45.diff</a>

</details>
