### PR TITLE
8269115: WebView paste event contains old data

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/DataObjectJava.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/DataObjectJava.h
@@ -74,10 +74,7 @@ public:
     }
 
     void clearData(const String& mimeType) {
-        size_t pos = m_availMimeTypes.find(mimeType);
-        if (pos != WTF::notFound) {
-            m_availMimeTypes.remove(pos);
-        }
+        m_availMimeTypes.remove(mimeType);
     }
 
     bool hasData() const {
@@ -86,15 +83,15 @@ public:
 
     //setters
     void setURL(const URL &url, const String &urlTitle) {
-        m_availMimeTypes.append(mimeURIList());
-        m_availMimeTypes.append(mimeShortcutName());
+        m_availMimeTypes.add(mimeURIList());
+        m_availMimeTypes.add(mimeShortcutName());
         m_url = url;
         m_urlTitle = urlTitle;
         m_filenames.clear();
     }
 
     void setFiles(const Vector<String> &filenames) {
-        m_availMimeTypes.append(mimeURIList());
+        m_availMimeTypes.add(mimeURIList());
         clearData(mimeShortcutName());
         m_url = emptyURL();
         m_urlTitle = emptyString();
@@ -102,12 +99,12 @@ public:
     }
 
     void setPlainText(const String &plainText){
-        m_availMimeTypes.append(mimePlainText());
+        m_availMimeTypes.add(mimePlainText());
         m_plainText = plainText;
     }
 
     void setHTML(const String &textHtml, const URL &htmlBaseUrl) {
-        m_availMimeTypes.append(mimeHTML());
+        m_availMimeTypes.add(mimeHTML());
         m_textHtml = textHtml;
         m_htmlBaseUrl = htmlBaseUrl;
     }
@@ -131,8 +128,9 @@ public:
     //getters
     //URL
     Vector<String> types() {
-        //returns MIME Types available in clipboard.
-        return m_availMimeTypes;
+        Vector<String> types;
+        types.appendRange(m_availMimeTypes.begin(), m_availMimeTypes.end());
+        return types; //returns MIME Types available in clipboard
     }
 
     String getData(const String& mimeType) {
@@ -216,7 +214,7 @@ public:
     }
 
 private:
-    Vector<String> m_availMimeTypes;
+    ListHashSet<String> m_availMimeTypes;
 
     //URL
     URL m_url;

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/PasteboardJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/PasteboardJava.cpp
@@ -237,6 +237,7 @@ std::unique_ptr<Pasteboard> Pasteboard::createForCopyAndPaste(std::unique_ptr<Pa
     static RefPtr<DataObjectJava> data = DataObjectJava::create();
     // TODO: setURL, setFiles, setData, setHtml (needs URL)
     data->setPlainText(jGetPlainText());
+    data->setData(DataObjectJava::mimeHTML(), jGetPlainText());
     return std::unique_ptr<Pasteboard>(new Pasteboard(data, true));
 }
 

--- a/tests/manual/web/ClipBoardDataTest.java
+++ b/tests/manual/web/ClipBoardDataTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
+import javafx.scene.layout.HBox;
+import javafx.scene.Scene;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+
+import java.io.File;
+
+public class ClipBoardDataTest extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+
+        VBox instructions =  new VBox(
+                new Label(" This test is for manual copy and paste clipboard events for webview , please follow below steps"),
+                new Label(" "),
+                new Label(" STEPS:"),
+                new Label("  1. Select the blue color text"),
+                new Label("  2. Right click on selected text and do copy."),
+                new Label("  3. Paste the text by ctrl + v or command +v"),
+                new Label(" "),
+                new Label("  Expected behaviour: on paste, a number would be displayed as 2"),
+                new Label("  Without fix , on paste a number would be displayed as 4 or more"));
+
+        Button passButton = new Button("Pass");
+        passButton.setOnAction(e -> {
+            Platform.exit();
+        });
+
+        Button failButton = new Button("Fail");
+        failButton.setOnAction(e -> {
+            Platform.exit();
+            throw new AssertionError("on paste the Data Nodes count is wrong.");
+        });
+
+        WebView webView = new WebView();
+        WebEngine webEngine = webView.getEngine();
+        webEngine.loadContent(
+                "<html>\n" +
+                        "<head> \n" +
+                        "   \n" +
+                        "</head>\n" +
+                        "<body>\n" +
+                        "<p id=\"data\" style=color:blue; >This is a test of the clipboard. select and manually copy me, and paste using ctrl+v:</p>\n" +
+                        "<div id=\"clipboardData\" contenteditable='true'></div>\n" +
+                        " <script>\n" +
+                        "        document.addEventListener('paste', e => {\n" +
+                        "            let messages = [];\n" +
+                        "            if (e.clipboardData.types) {\n" +
+                        "                let message_index = 0;\n" +
+                        "                e.clipboardData.types.forEach(type => {\n" +
+                        "                    messages.push( type + \": \" + e.clipboardData.getData(type));\n" +
+                        "                    const para = document.createElement(\"p\");\n" +
+                        "                    para.innerText = type + \": \" + e.clipboardData.getData(type);\n" +
+                        "                    document.getElementById(\"clipboardData\").innerText = ++message_index;\n" +
+                        "                });\n" +
+                        "            }\n" +
+                        "        });\n" +
+                        "</script>\n" +
+                        "</body>\n" +
+                        "</html>");
+
+        HBox buttons = new HBox(20, passButton, failButton);
+        buttons.setPadding(new Insets(10));
+        VBox rootNode = new VBox(20, new HBox(instructions), webView, buttons);
+        rootNode.setPadding(new Insets(10));
+        Scene scene = new Scene(rootNode, 1000, 600);
+        primaryStage.setScene(scene);
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}


### PR DESCRIPTION
Reviewed-by: arapte, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269115](https://bugs.openjdk.java.net/browse/JDK-8269115): WebView paste event contains old data


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/46.diff">https://git.openjdk.java.net/jfx17u/pull/46.diff</a>

</details>
