### PR TITLE
8274137: TableView scrollbar/header misaligned when reloading data

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -590,6 +590,8 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         verticalProperty().addListener(listenerX);
         hbar.valueProperty().addListener(listenerX);
         hbar.visibleProperty().addListener(listenerX);
+        visibleProperty().addListener(listenerX);
+        sceneProperty().addListener(listenerX);
 
 //        ChangeListener listenerY = new ChangeListener() {
 //            @Override public void handle(Bean bean, PropertyReference property) {

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
@@ -85,6 +85,10 @@ public class VirtualFlowShim<T extends IndexedCell> extends VirtualFlow<T> {
         return super.clipView.getHeight();
     }
 
+    public double get_clipView_getX() {
+        return - super.clipView.getLayoutX();
+    }
+
 
     public StackPane get_corner() {
         return super.corner;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -40,10 +40,12 @@ import javafx.beans.InvalidationListener;
 import javafx.event.Event;
 import javafx.scene.control.IndexedCell;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.shape.Circle;
 
 import test.javafx.scene.control.SkinStub;
 import javafx.scene.input.ScrollEvent;
+import javafx.scene.layout.HBox;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -1316,6 +1318,32 @@ public class VirtualFlowTest {
             cell = vf.get_accumCell();
             if (cell != null) assertFalse(cell.isVisible());
         }
+    }
+
+    @Test public void testScrollBarClipSyncWhileInvisibleOrNoScene() {
+        flow.setCellCount(3);
+        flow.resize(50, flow.getHeight());
+        pulse();
+
+        flow.setVisible(true);
+        Scene scene = new Scene(flow);
+        // sync works with both scene in place and flow visible
+        assertEquals(flow.shim_getHbar().getValue(), flow.get_clipView_getX(), 0);
+        flow.shim_getHbar().setValue(42);
+        assertEquals(flow.shim_getHbar().getValue(), flow.get_clipView_getX(), 0);
+
+        // sync works with flow invisible
+        flow.setVisible(false);
+        flow.shim_getHbar().setValue(21);
+        flow.setVisible(true);
+        assertEquals(flow.shim_getHbar().getValue(), flow.get_clipView_getX(), 0);
+
+        // sync works with no scene
+        scene.setRoot(new HBox());
+        assertEquals(null, flow.getScene());
+        flow.shim_getHbar().setValue(10);
+        scene.setRoot(flow);
+        assertEquals(flow.shim_getHbar().getValue(), flow.get_clipView_getX(), 0);
     }
 }
 


### PR DESCRIPTION
Reviewed-by: kcr, aghaisas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274137](https://bugs.openjdk.java.net/browse/JDK-8274137): TableView scrollbar/header misaligned when reloading data


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/49.diff">https://git.openjdk.java.net/jfx17u/pull/49.diff</a>

</details>
