### PR TITLE
8276167: VirtualFlow.scrollToTop doesn't scroll to the top of the last element

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1581,7 +1581,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     public void scrollToTop(int index) {
         boolean posSet = false;
 
-        if (index >= getCellCount() - 1) {
+        if (index > getCellCount() - 1) {
             setPosition(1);
             posSet = true;
         } else if (index < 0) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewKeyInputTest.java
@@ -1861,11 +1861,11 @@ public class ListViewKeyInputTest {
         final int diff = 99 - leadSelectedIndex;
         assertEquals(99 - diff, leadSelectedIndex);
         assertEquals(99 - diff, fm.getFocusedIndex());
-        assertEquals(7, selectedIndicesCount);
+        assertEquals(8, selectedIndicesCount);
 
         keyboard.doKeyPress(KeyCode.PAGE_UP, KeyModifier.SHIFT);
-        assertEquals(99 - diff * 2, sm.getSelectedIndex());
-        assertEquals(selectedIndicesCount * 2 - 1, sm.getSelectedIndices().size());
+        assertEquals(99 - diff * 2 + 1, sm.getSelectedIndex());
+        assertEquals(selectedIndicesCount * 2 - 2, sm.getSelectedIndices().size());
 
         keyboard.doKeyPress(KeyCode.PAGE_DOWN, KeyModifier.SHIFT);
         assertEquals(leadSelectedIndex, sm.getSelectedIndex());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -3660,7 +3660,7 @@ public class TreeTableViewTest {
         // However, for now, we'll test on the assumption that across all
         // platforms we only get one extra cell created, and we can loosen this
         // up if necessary.
-        assertEquals(cellCountAtStart + 13, rt36452_instanceCount);
+        assertEquals(cellCountAtStart + 14, rt36452_instanceCount);
 
         sl.dispose();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1144,6 +1144,43 @@ public class VirtualFlowTest {
     }
 
     @Test
+    public void testScrollToTopOfLastLargeCell() {
+        double flowHeight = 150;
+        int cellCount = 2;
+
+        flow = new VirtualFlowShim<>();
+        flow.setCellFactory(p -> new CellStub(flow) {
+            @Override
+            protected double computePrefHeight(double width) {
+                return getIndex() == cellCount -1 ? 200 : 100;
+            }
+
+            @Override
+            protected double computeMinHeight(double width) {
+                return computePrefHeight(width);
+            }
+
+            @Override
+            protected double computeMaxHeight(double width) {
+                return computePrefHeight(width);
+            }
+        });
+        flow.setVertical(true);
+
+        flow.resize(50,flowHeight);
+        flow.setCellCount(cellCount);
+        pulse();
+
+        flow.scrollToTop(cellCount - 1);
+        pulse();
+
+        IndexedCell<?> cell = flow.getCell(cellCount - 1);
+        double cellPosition = flow.getCellPosition(cell);
+
+        assertEquals("Last cell must be aligned to top of the viewport", 0, cellPosition, 0.1);
+    }
+
+    @Test
     public void testImmediateScrollTo() {
         flow.setCellCount(100);
         flow.scrollTo(90);


### PR DESCRIPTION
Reviewed-by: aghaisas, jvos

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276167](https://bugs.openjdk.java.net/browse/JDK-8276167): VirtualFlow.scrollToTop doesn't scroll to the top of the last element


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx17u pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.java.net/jfx17u pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx17u/pull/52.diff">https://git.openjdk.java.net/jfx17u/pull/52.diff</a>

</details>
