### PR TITLE
Backport d289db94d15e49ed28f797b516ffccf023fce9c9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,7 +408,9 @@ if (IS_STATIC_BUILD && IS_COMPILE_MEDIA) {
 }
 
 // By default, target architecture = host architecture, but we allow different ones.
-defineProperty("TARGET_ARCH", OS_ARCH)
+// On Apple Silicon, default architecture must be "arm64", because clang does not accept
+// aarch64 as -arch parameter.
+defineProperty("TARGET_ARCH", (IS_MAC && IS_AARCH64) ? "arm64" : OS_ARCH)
 
 // BUILD_TOOLS_DOWNLOAD_SCRIPT specifies a path of a gradle script which downloads
 // required build tools.


### PR DESCRIPTION
Clean backport to `jfx17u` so we can build on macOS / aarch64 without needing to specify `-PCOMPILE_TARGET=arm64`.