### PR TITLE
8271054: [REDO] Wrong stage gets focused after modal stage creation

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
@@ -396,6 +396,9 @@ class WindowContextTop: public WindowContextBase {
 
     static WindowFrameExtents normal_extents;
     static WindowFrameExtents utility_extents;
+
+    long event_serial;
+
 public:
     WindowContextTop(jobject, WindowContext*, long, WindowFrameType, WindowType, GdkWMFunction);
     void process_map();
@@ -432,6 +435,8 @@ public:
 
     GtkWindow *get_gtk_window();
     void detach_from_java();
+    void process_key(GdkEventKey*);
+    void process_mouse_button(GdkEventButton*);
 protected:
     void applyShapeMask(void*, uint width, uint height);
 private:


### PR DESCRIPTION
Clean backport of 8271054: [REDO] Wrong stage gets focused after modal stage creation
Reviewed-by: kcr, arapte

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271054](https://bugs.openjdk.org/browse/JDK-8271054): [REDO] Wrong stage gets focused after modal stage creation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/jfx17u pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/63.diff">https://git.openjdk.org/jfx17u/pull/63.diff</a>

</details>
