### PR TITLE
8284654: Modal behavior returns to wrong stage

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -899,7 +899,8 @@ class WindowStage extends GlassStage {
         }
         if (enabled) {
             // Check if window is really enabled - to handle nested case
-            if (platformWindow != null && platformWindow.isEnabled()) {
+            if (platformWindow != null && platformWindow.isEnabled()
+                    && modality == Modality.APPLICATION_MODAL) {
                 requestToFront();
             }
         } else {


### PR DESCRIPTION
clean backport of 8284654: Modal behavior returns to wrong stage
Reviewed-by: arapte, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284654](https://bugs.openjdk.org/browse/JDK-8284654): Modal behavior returns to wrong stage


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/jfx17u pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/64.diff">https://git.openjdk.org/jfx17u/pull/64.diff</a>

</details>
