### PR TITLE
8282093: LineChart path incorrect when outside lower bound

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/AreaChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/AreaChart.java
@@ -467,8 +467,8 @@ public class AreaChart<X,Y> extends XYChart<X,Y> {
             if (x < dataXMin || y < dataYMin) {
                 if (prevDataPoint == null) {
                     prevDataPoint = new LineTo(x, y);
-                } else if ((sortX && prevDataPoint.getX() < x) ||
-                           (sortY && prevDataPoint.getY() < y))
+                } else if ((sortX && prevDataPoint.getX() <= x) ||
+                           (sortY && prevDataPoint.getY() <= y))
                 {
                     prevDataPoint.setX(x);
                     prevDataPoint.setY(y);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/AreaChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/AreaChartTest.java
@@ -170,7 +170,27 @@ public class AreaChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(series1).toArray(), findDataPointsFromPathLine(ac).toArray());
     }
 
-    @Test public void testPathOutsideXBoundsWithDuplicateXAndHigherY() {
+    @Test public void testPathOutsideXLowerBoundsWithDuplicateXAndHigherY() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(-10d, 20d)); // lower bound is 0
+        series1.getData().add(new XYChart.Data<>(-10d, 50d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(-10d, 50d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXUpperBoundsWithDuplicateXAndHigherY() {
         startApp();
         series1.getData().add(new XYChart.Data<>(100d, 20d)); // upper bound is 90
         series1.getData().add(new XYChart.Data<>(100d, 50d));
@@ -190,7 +210,27 @@ public class AreaChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
     }
 
-    @Test public void testPathOutsideXBoundsWithDuplicateXAndLowerY() {
+    @Test public void testPathOutsideXLowerBoundsWithDuplicateXAndLowerY() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(-10d, 20d)); // lower bound is 0
+        series1.getData().add(new XYChart.Data<>(-10d, 15d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(-10d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXUpperBoundsWithDuplicateXAndLowerY() {
         startApp();
         series1.getData().add(new XYChart.Data<>(100d, 20d)); // upper bound is 90
         series1.getData().add(new XYChart.Data<>(100d, 15d));
@@ -210,9 +250,31 @@ public class AreaChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
     }
 
-    @Test public void testPathOutsideYBoundsWithDuplicateYAndLowerX() {
+    @Test public void testPathOutsideYLowerBoundsWithDuplicateYAndLowerX() {
         startApp();
-        series1.getData().add(new XYChart.Data<>(85d, 40d));
+        series1.getData().add(new XYChart.Data<>(85d, -10d)); // y-axis lower bound is 0
+        series1.getData().add(new XYChart.Data<>(70d, -10d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                // Sorting policy in AreaChart is defaulted to X_AXIS. See AreaChart#makePaths
+                new XYChart.Data<>(70d, -10d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(85d, -10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideYUpperBoundsWithDuplicateYAndLowerX() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(85d, 40d));  // y-axis upper bound is 30
         series1.getData().add(new XYChart.Data<>(70d, 40d));
         ac.getData().addAll(series1);
         pulse();
@@ -232,7 +294,28 @@ public class AreaChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
     }
 
-    @Test public void testPathOutsideYBoundsWithDuplicateYAndHigherX() {
+    @Test public void testPathOutsideYLowerBoundsWithDuplicateYAndHigherX() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(70d, -10d)); // lower bound is 30
+        series1.getData().add(new XYChart.Data<>(85d, -10d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(70d, -10d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(85d, -10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideYUpperBoundsWithDuplicateYAndHigherX() {
         startApp();
         series1.getData().add(new XYChart.Data<>(70d, 32d)); // upper bound is 30
         series1.getData().add(new XYChart.Data<>(85d, 32d));
@@ -253,7 +336,27 @@ public class AreaChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
     }
 
-    @Test public void testPathOutsideXAndYBoundsWithDuplicateXAndHigherY() {
+    @Test public void testPathOutsideXAndYLowerBoundsWithDuplicateXAndHigherY() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(-10d, -40d)); // lower bound is 0,0
+        series1.getData().add(new XYChart.Data<>(-10d, -30d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(-10d, -30d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYUpperBoundsWithDuplicateXAndHigherY() {
         startApp();
         series1.getData().add(new XYChart.Data<>(95d, 35d)); // upper bound is 90,30
         series1.getData().add(new XYChart.Data<>(95d, 40d));
@@ -273,7 +376,27 @@ public class AreaChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
     }
 
-    @Test public void testPathOutsideXAndYBoundsWithDuplicateXAndLowerY() {
+    @Test public void testPathOutsideXAndYLowerBoundsWithDuplicateXAndLowerY() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(-10d, -30d)); // lower bound is 0,0
+        series1.getData().add(new XYChart.Data<>(-10d, -40d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(-10d, -40d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYUpperBoundsWithDuplicateXAndLowerY() {
         startApp();
         series1.getData().add(new XYChart.Data<>(95d, 40d)); // upper bound is 90,30
         series1.getData().add(new XYChart.Data<>(95d, 35d));
@@ -293,7 +416,27 @@ public class AreaChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
     }
 
-    @Test public void testPathOutsideXAndYBoundsWithDuplicateYAndHigherX() {
+    @Test public void testPathOutsideXAndYLowerBoundsWithDuplicateYAndHigherX() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(-20d, -30d)); // lower bound is 0,0
+        series1.getData().add(new XYChart.Data<>(-10d, -30d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(-10d, -30d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYUpperBoundsWithDuplicateYAndHigherX() {
         startApp();
         series1.getData().add(new XYChart.Data<>(95d, 32d)); // upper bound is 90,30
         series1.getData().add(new XYChart.Data<>(100d, 32d));
@@ -313,7 +456,27 @@ public class AreaChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
     }
 
-    @Test public void testPathOutsideXAndYBoundsWithDuplicateYAndLowerX() {
+    @Test public void testPathOutsideXAndYLowerBoundsWithDuplicateYAndLowerX() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(-10d, -30d)); // lower bound is 0,0
+        series1.getData().add(new XYChart.Data<>(-20d, -30d));
+        ac.getData().addAll(series1);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(-10d, -30d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(ac).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYUpperBoundsWithDuplicateYAndLowerX() {
         startApp();
         series1.getData().add(new XYChart.Data<>(100d, 40d)); // upper bound is 90,30
         series1.getData().add(new XYChart.Data<>(95d, 40d));

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/LineChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/LineChartTest.java
@@ -339,7 +339,29 @@ public class LineChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
     }
 
-    @Test public void testPathOutsideXBoundsWithDuplicateXAndHigherYWithSortYAxis() {
+    @Test public void testPathOutsideXLowerBoundsWithDuplicateXAndHigherYWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data(-10d, 20d)); // lower bound is 0
+        series1.getData().add(new XYChart.Data(-10d, 50d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(-10d, 50d),
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(-10d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXUpperBoundsWithDuplicateXAndHigherYWithSortYAxis() {
         startApp();
         series1.getData().add(new XYChart.Data(100d, 20d)); // upper bound is 90
         series1.getData().add(new XYChart.Data(100d, 50d));
@@ -361,7 +383,29 @@ public class LineChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
     }
 
-    @Test public void testPathOutsideXBoundsWithDuplicateXAndLowerYWithSortYAxis() {
+    @Test public void testPathOutsideXLowerBoundsWithDuplicateXAndLowerYWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data(-10d, 20d)); // lower bound is 0
+        series1.getData().add(new XYChart.Data(-10d, 15d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(-10d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(-10d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXUpperBoundsWithDuplicateXAndLowerYWithSortYAxis() {
         startApp();
         series1.getData().add(new XYChart.Data(100d, 20d)); // upper bound is 90
         series1.getData().add(new XYChart.Data(100d, 15d));
@@ -383,7 +427,28 @@ public class LineChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
     }
 
-    @Test public void testPathOutsideYBoundsWithDuplicateYAndHigherXWithSortYAxis() {
+    @Test public void testPathOutsideYLowerBoundsWithDuplicateYAndHigherXWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data(80d, -10d)); // lower bound is 0
+        series1.getData().add(new XYChart.Data(90d, -10d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(80d, -10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideYUpperBoundsWithDuplicateYAndHigherXWithSortYAxis() {
         startApp();
         series1.getData().add(new XYChart.Data(80d, 32d)); // upper bound is 30
         series1.getData().add(new XYChart.Data(90d, 32d));
@@ -393,7 +458,7 @@ public class LineChartTest extends XYChartTestBase {
 
         XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
         expectedSeries.getData().addAll(
-                new XYChart.Data<>(80d, 32d),
+                new XYChart.Data<>(90d, 32d),
                 new XYChart.Data<>(25d, 20d),
                 new XYChart.Data<>(30d, 15d),
                 new XYChart.Data<>(50d, 15d),
@@ -404,7 +469,27 @@ public class LineChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
     }
 
-    @Test public void testPathOutsideYBoundsWithDuplicateYAndLowerXWithSortYAxis() {
+    @Test public void testPathOutsideYLowerBoundsWithDuplicateYAndLowerXWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data(80d, -10d)); // lower bound is 0
+        series1.getData().add(new XYChart.Data(70d, -10d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(80d, -10d)
+        );
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideYUpperBoundsWithDuplicateYAndLowerXWithSortYAxis() {
         startApp();
         series1.getData().add(new XYChart.Data(80d, 40d)); // upper bound is 30
         series1.getData().add(new XYChart.Data(70d, 40d));
@@ -414,7 +499,7 @@ public class LineChartTest extends XYChartTestBase {
 
         XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
         expectedSeries.getData().addAll(
-                new XYChart.Data<>(80d, 40d),
+                new XYChart.Data<>(70d, 40d),
                 new XYChart.Data<>(25d, 20d),
                 new XYChart.Data<>(30d, 15d),
                 new XYChart.Data<>(50d, 15d),
@@ -425,7 +510,29 @@ public class LineChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
     }
 
-    @Test public void testPathOutsideXAndYBoundsWithDuplicateXAndHigherYWithSortYAxis() {
+    @Test public void testPathOutsideXAndYLowerBoundsWithDuplicateXAndHigherYWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(95d, -10d)); // lower bound is 0,0
+        series1.getData().add(new XYChart.Data<>(95d, -5d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(95d, -5d)/*,
+                new XYChart.Data<>(95d, -10d)*/
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYUpperBoundsWithDuplicateXAndHigherYWithSortYAxis() {
         startApp();
         series1.getData().add(new XYChart.Data<>(95d, 35d)); // upper bound is 90,30
         series1.getData().add(new XYChart.Data<>(95d, 40d));
@@ -446,7 +553,28 @@ public class LineChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
     }
 
-    @Test public void testPathOutsideXAndYBoundsWithDuplicateXAndLowerYWithSortYAxis() {
+    @Test public void testPathOutsideXAndYLowerBoundsWithDuplicateXAndLowerYWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(-10d, -10d)); // lower bound is 0,0
+        series1.getData().add(new XYChart.Data<>(-10d, -20d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(-10d, -10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYUpperBoundsWithDuplicateXAndLowerYWithSortYAxis() {
         startApp();
         series1.getData().add(new XYChart.Data<>(95d, 40d)); // upper bound is 90,30
         series1.getData().add(new XYChart.Data<>(95d, 35d));
@@ -467,7 +595,28 @@ public class LineChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
     }
 
-    @Test public void testPathOutsideXAndYBoundsWithDuplicateYAndHigherXWithSortYAxis() {
+    @Test public void testPathOutsideXAndYLowerBoundsWithDuplicateYAndHigherXWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(-15d, -10d)); // lower bound is 0,0
+        series1.getData().add(new XYChart.Data<>(-10d, -10d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(-15d, -10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYUpperBoundsWithDuplicateYAndHigherXWithSortYAxis() {
         startApp();
         series1.getData().add(new XYChart.Data<>(95d, 32d)); // upper bound is 90,30
         series1.getData().add(new XYChart.Data<>(100d, 32d));
@@ -477,7 +626,7 @@ public class LineChartTest extends XYChartTestBase {
 
         XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
         expectedSeries.getData().addAll(
-                new XYChart.Data<>(95d, 32d),
+                new XYChart.Data<>(100d, 32d),
                 new XYChart.Data<>(25d, 20d),
                 new XYChart.Data<>(30d, 15d),
                 new XYChart.Data<>(50d, 15d),
@@ -488,7 +637,28 @@ public class LineChartTest extends XYChartTestBase {
         assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
     }
 
-    @Test public void testPathOutsideXAndYBoundsWithDuplicateYAndLowerXWithSortYAxis() {
+    @Test public void testPathOutsideXAndYLowerBoundsWithDuplicateYAndLowerXWithSortYAxis() {
+        startApp();
+        series1.getData().add(new XYChart.Data<>(-10d, -10d)); // lower bound is 0,0
+        series1.getData().add(new XYChart.Data<>(-15d, -10d));
+        lineChart.getData().addAll(series1);
+        lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+        pulse();
+
+        XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
+        expectedSeries.getData().addAll(
+                new XYChart.Data<>(25d, 20d),
+                new XYChart.Data<>(30d, 15d),
+                new XYChart.Data<>(50d, 15d),
+                new XYChart.Data<>(10d, 10d),
+                new XYChart.Data<>(80d, 10d),
+                new XYChart.Data<>(-10d, -10d)
+        );
+
+        assertArrayEquals(convertSeriesDataToPoint2D(expectedSeries).toArray(), findDataPointsFromPathLine(lineChart).toArray());
+    }
+
+    @Test public void testPathOutsideXAndYUpperBoundsWithDuplicateYAndLowerXWithSortYAxis() {
         startApp();
         series1.getData().add(new XYChart.Data<>(100d, 40d)); // upper bound is 90,30
         series1.getData().add(new XYChart.Data<>(95d, 40d));
@@ -498,7 +668,7 @@ public class LineChartTest extends XYChartTestBase {
 
         XYChart.Series<Number, Number> expectedSeries = new XYChart.Series<>();
         expectedSeries.getData().addAll(
-                new XYChart.Data<>(100d, 40d),
+                new XYChart.Data<>(95d, 40d),
                 new XYChart.Data<>(25d, 20d),
                 new XYChart.Data<>(30d, 15d),
                 new XYChart.Data<>(50d, 15d),

--- a/tests/manual/controls/LineGraphBoundsSample.java
+++ b/tests/manual/controls/LineGraphBoundsSample.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javafx.application.Application;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.HPos;
+import javafx.geometry.Insets;
+import javafx.geometry.Point2D;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.chart.LineChart;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.stage.Stage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LineGraphBoundsSample extends Application {
+
+    @Override
+    public void start(Stage primaryStage) {
+        NumberAxis yAxis = new NumberAxis();
+        NumberAxis xAxis = new NumberAxis();
+        LineChart<Number, Number> lineChart = new LineChart<>(xAxis, yAxis);
+
+        DoubleProperty lowerBound = new SimpleDoubleProperty(0);
+        DoubleProperty upperBound = new SimpleDoubleProperty(2);
+
+        final ComboBox<String> axisSelection = new ComboBox<>(FXCollections.observableArrayList("X-Axis", "Y-Axis"));
+        axisSelection.getSelectionModel().selectedIndexProperty().addListener((o, ov, nv) -> {
+            switch (nv.intValue()) {
+                case 0:
+                    lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.X_AXIS);
+                    lineChart.setData(createData(LineChart.SortingPolicy.X_AXIS));
+                    lineChart.getXAxis().setAutoRanging(false);
+                    lineChart.getYAxis().setAutoRanging(true);
+                    ((NumberAxis) lineChart.getXAxis()).lowerBoundProperty().bind(lowerBound);
+                    ((NumberAxis) lineChart.getXAxis()).upperBoundProperty().bind(upperBound);
+                    ((NumberAxis) lineChart.getYAxis()).lowerBoundProperty().unbind();
+                    ((NumberAxis) lineChart.getYAxis()).upperBoundProperty().unbind();
+                    break;
+                case 1:
+                    lineChart.setAxisSortingPolicy(LineChart.SortingPolicy.Y_AXIS);
+                    lineChart.setData(createData(LineChart.SortingPolicy.Y_AXIS));
+                    lineChart.getXAxis().setAutoRanging(true);
+                    lineChart.getYAxis().setAutoRanging(false);
+                    ((NumberAxis) lineChart.getXAxis()).lowerBoundProperty().unbind();
+                    ((NumberAxis) lineChart.getXAxis()).upperBoundProperty().unbind();
+                    ((NumberAxis) lineChart.getYAxis()).lowerBoundProperty().bind(lowerBound);
+                    ((NumberAxis) lineChart.getYAxis()).upperBoundProperty().bind(upperBound);
+                    break;
+            }
+            lowerBound.set(0);
+            upperBound.set(2);
+        });
+
+        Button decrement = new Button("Decrease Bound");
+        decrement.setOnAction(e -> {
+            final double CHANGE_VALUE = -0.1;
+            lowerBound.set(lowerBound.get() + CHANGE_VALUE);
+            upperBound.set(upperBound.get() + CHANGE_VALUE);
+        });
+
+        Button increment = new Button("Increase Bound");
+        increment.setOnAction(e -> {
+            final double CHANGE_VALUE = 0.1;
+            lowerBound.set(lowerBound.get() + CHANGE_VALUE);
+            upperBound.set(upperBound.get() + CHANGE_VALUE);
+        });
+
+        final TextField lowerBoundTextField = new TextField();
+        lowerBoundTextField.setEditable(false);
+        lowerBoundTextField.textProperty().bind(lowerBound.asString("%.2f"));
+
+        final TextField upperBoundTextField = new TextField();
+        upperBoundTextField.setEditable(false);
+        upperBoundTextField.textProperty().bind(upperBound.asString("%.2f"));
+
+        final BorderPane root = new BorderPane();
+        final GridPane gridPane = new GridPane();
+        gridPane.setVgap(5);
+        gridPane.setHgap(5);
+        gridPane.setPadding(new Insets(10));
+        gridPane.add(new Label("Sorting Policy: "), 0, 0);
+        gridPane.add(axisSelection, 1, 0);
+        gridPane.add(new Label("Lower Bound: "), 2, 0);
+        gridPane.add(new Label("Upper Bound: "), 2, 1);
+        gridPane.add(lowerBoundTextField, 3, 0);
+        gridPane.add(upperBoundTextField, 3, 1);
+        final HBox buttons = new HBox(10, decrement, increment);
+        buttons.setAlignment(Pos.CENTER);
+        GridPane.setHalignment(buttons, HPos.CENTER);
+        gridPane.add(buttons, 0, 2, 4,1);
+        root.setTop(gridPane);
+        root.setCenter(lineChart);
+
+        Scene scene = new Scene(root);
+        primaryStage.setScene(scene);
+        primaryStage.show();
+
+        axisSelection.getSelectionModel().select(0);
+    }
+
+    private ObservableList<XYChart.Series<Number,Number>> createData(LineChart.SortingPolicy sortingPolicy) {
+        XYChart.Series<Number, Number> series = new XYChart.Series<>();
+        List<Point2D> points = new ArrayList<>();
+        switch (sortingPolicy) {
+            case X_AXIS:
+                points.addAll(List.of(
+                        new Point2D(0.4, 0.5),
+                        new Point2D(0.8, 0.5),
+                        new Point2D(0.8, 1.0),
+                        new Point2D(1.0, 1.0),
+                        new Point2D(1.0, 0.8),
+                        new Point2D(1.5, 0.8)
+                ));
+                break;
+            case Y_AXIS:
+                points.addAll(List.of(
+                        new Point2D(0.5, 1.3),
+                        new Point2D(0.5, 0.9),
+                        new Point2D(1.0, 0.9),
+                        new Point2D(1.0, 0.7),
+                        new Point2D(0.8, 0.7),
+                        new Point2D(0.8, 0.5)
+                ));
+                break;
+        }
+        points.forEach(point -> {
+            series.getData().add(new XYChart.Data<>(point.getX(), point.getY()));
+        });
+        return FXCollections.observableArrayList(series);
+    }
+}


### PR DESCRIPTION
Clean backport of 8282093: LineChart path incorrect when outside lower bound
Reviewed-by: aghaisas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282093](https://bugs.openjdk.org/browse/JDK-8282093): LineChart path incorrect when outside lower bound


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jfx17u pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/65.diff">https://git.openjdk.org/jfx17u/pull/65.diff</a>

</details>
