### PR TITLE
8193442: Removing TreeItem from a TreeTableView sometime changes selectedItem

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
@@ -217,4 +217,19 @@ class ControlUtils {
 
         sm.selectedIndices._endChange();
     }
+
+    public static <S> int getIndexOfChildWithDescendant(TreeItem<S> parent, TreeItem<S> item) {
+        if (item == null || parent == null) {
+            return -1;
+        }
+        TreeItem<S> child = item, ancestor = item.getParent();
+        while (ancestor != null) {
+            if (ancestor == parent) {
+                return parent.getChildren().indexOf(child);
+            }
+            child = ancestor;
+            ancestor = child.getParent();
+        }
+        return -1;
+    }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -2629,9 +2629,6 @@ public class TreeTableView<S> extends Control {
                             }
                         }
                     } else if (e.wasRemoved()) {
-                        // shuffle selection by the number of removed items
-                        shift += treeItem.isExpanded() ? -removedSize : 0;
-
                         // the start row is incorrect - it is _not_ the index of the
                         // TreeItem in which the children were removed from (which is
                         // what it currently represents). We need to take the 'from'
@@ -2646,6 +2643,19 @@ public class TreeTableView<S> extends Control {
                         final List<TreeItem<S>> selectedItems = getSelectedItems();
                         final TreeItem<S> selectedItem = getSelectedItem();
                         final List<? extends TreeItem<S>> removedChildren = e.getChange().getRemoved();
+
+                        // shuffle selection by the number of removed items
+                        // only if removed items are before the current selection.
+                        if (treeItem.isExpanded()) {
+                            int lastSelectedSiblingIndex = selectedItems.stream()
+                                    .map(item -> ControlUtils.getIndexOfChildWithDescendant(treeItem, item))
+                                    .max(Comparator.naturalOrder())
+                                    .orElse(-1);
+                            // shift only if the last selected sibling index is after the first removed child
+                            if (e.getFrom() <= lastSelectedSiblingIndex || lastSelectedSiblingIndex == -1) {
+                                shift -= removedSize;
+                            }
+                        }
 
                         for (int i = 0; i < selectedIndices.size() && !selectedItems.isEmpty(); i++) {
                             int index = selectedIndices.get(i);
@@ -3502,9 +3512,12 @@ public class TreeTableView<S> extends Control {
                             }
                         }
 
-                        if (row <= getFocusedIndex()) {
-                            // shuffle selection by the number of removed items
-                            shift += e.getTreeItem().isExpanded() ? -e.getRemovedSize() : 0;
+                        if (e.getTreeItem().isExpanded()) {
+                            int focusedSiblingRow = ControlUtils.getIndexOfChildWithDescendant(e.getTreeItem(), getFocusedItem());
+                            if (e.getFrom() <= focusedSiblingRow) {
+                                // shuffle selection by the number of removed items
+                                shift -= e.getRemovedSize();
+                            }
                         }
                     }
                 } while (e.getChange() != null && e.getChange().next());

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
@@ -66,6 +66,7 @@ import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1407,9 +1408,6 @@ public class TreeView<T> extends Control {
                     // subsequently commented out due to RT-33894.
                     startRow = treeView.getRow(e.getChange().getAddedSubList().get(0));
                 } else if (e.wasRemoved()) {
-                    // shuffle selection by the number of removed items
-                    shift += treeItem.isExpanded() ? -removedSize : 0;
-
                     // the start row is incorrect - it is _not_ the index of the
                     // TreeItem in which the children were removed from (which is
                     // what it currently represents). We need to take the 'from'
@@ -1425,6 +1423,19 @@ public class TreeView<T> extends Control {
                     final List<TreeItem<T>> selectedItems = getSelectedItems();
                     final TreeItem<T> selectedItem = getSelectedItem();
                     final List<? extends TreeItem<T>> removedChildren = e.getChange().getRemoved();
+
+                    // shuffle selection by the number of removed items
+                    // only if removed items are before the current selection.
+                    if (treeItem.isExpanded()) {
+                        int lastSelectedSiblingIndex = selectedItems.stream()
+                                .map(item -> ControlUtils.getIndexOfChildWithDescendant(treeItem, item))
+                                .max(Comparator.naturalOrder())
+                                .orElse(-1);
+                        // shift only if the last selected sibling index is after the first removed child
+                        if (e.getFrom() <= lastSelectedSiblingIndex || lastSelectedSiblingIndex == -1) {
+                            shift -= removedSize;
+                        }
+                    }
 
                     for (int i = 0; i < selectedIndices1.size() && !selectedItems.isEmpty(); i++) {
                         int index = selectedIndices1.get(i);
@@ -1686,9 +1697,12 @@ public class TreeView<T> extends Control {
                             }
                         }
 
-                        if (row <= getFocusedIndex()) {
-                            // shuffle selection by the number of removed items
-                            shift += e.getTreeItem().isExpanded() ? -e.getRemovedSize() : 0;
+                        if (e.getTreeItem().isExpanded()) {
+                            int focusedSiblingRow = ControlUtils.getIndexOfChildWithDescendant(e.getTreeItem(), getFocusedItem());
+                            if (e.getFrom() <= focusedSiblingRow) {
+                                // shuffle selection by the number of removed items
+                                shift -= e.getRemovedSize();
+                            }
                         }
                     }
                 } while (e.getChange() != null && e.getChange().next());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 import com.sun.javafx.scene.control.behavior.TreeTableCellBehavior;
 import javafx.beans.property.ReadOnlyIntegerWrapper;
 import javafx.collections.transformation.FilteredList;
+import javafx.scene.control.SelectionModel;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import test.javafx.collections.MockListObserver;
@@ -1568,7 +1569,6 @@ public class TreeTableViewTest {
         assertEquals(mikeGraham, treeTableView.getFocusModel().getFocusedItem());
     }
 
-    @Ignore("Bug hasn't been fixed yet")
     @Test public void test_rt28114() {
         myCompanyRootNode.setExpanded(true);
         treeTableView.setRoot(myCompanyRootNode);
@@ -1584,8 +1584,6 @@ public class TreeTableViewTest {
         itSupport.getChildren().remove(mikeGraham);
         assertEquals(itSupport, treeTableView.getFocusModel().getFocusedItem());
         assertEquals(itSupport, treeTableView.getSelectionModel().getSelectedItem());
-        assertTrue(itSupport.isLeaf());
-        assertTrue(!itSupport.isExpanded());
     }
 
     @Test public void test_rt27820_1() {
@@ -6713,6 +6711,74 @@ public class TreeTableViewTest {
         assertFalse(sm.isSelected(1, lastNameCol));
         assertEquals(1, sm.getSelectedCells().size());
         assertEquals(1, sm.getSelectedItems().size());
+    }
+
+    // JDK-8187596
+    @Test
+    public void testRemoveTreeItemShiftSelection() {
+        TreeItem<String> a, b, a1, a2, a3;
+        TreeItem<String> root = new TreeItem<>("root");
+        root.getChildren().addAll(
+                a = new TreeItem<>("a"),
+                b = new TreeItem<>("b")
+        );
+        root.setExpanded(true);
+
+        a.getChildren().addAll(
+                a1 = new TreeItem<>("a1"),
+                a2 = new TreeItem<>("a2"),
+                a3 = new TreeItem<>("a3")
+        );
+        a.setExpanded(true);
+
+        TreeTableView<String> stringTreeTableView = new TreeTableView<>(root);
+        TreeTableColumn<String, String> column = new TreeTableColumn<>("Nodes");
+        column.setCellValueFactory(p -> new ReadOnlyStringWrapper(p.getValue().getValue()));
+        column.setPrefWidth(200);
+        stringTreeTableView.getColumns().add(column);
+
+        stringTreeTableView.setShowRoot(false);
+        SelectionModel sm = stringTreeTableView.getSelectionModel();
+
+        sm.clearAndSelect(3); //select a3
+        assertEquals(a3, sm.getSelectedItem()); //verify
+        root.getChildren().remove(b); //remove b
+        //a3 should remain selected
+        assertEquals(3, sm.getSelectedIndex());
+        assertEquals(a3, sm.getSelectedItem());
+    }
+
+    // JDK-8193442
+    @Test
+    public void testRemoveTreeItemChangesSelectedItem() {
+        TreeItem<String> rootNode = new TreeItem<>("Root");
+        rootNode.setExpanded(true);
+        for (int i = 0; i < 3; i++) {
+            rootNode.getChildren().add(new TreeItem<>("Node " + i));
+        }
+        for (int i = 0; i < 2; i++) {
+            TreeItem<String> node = rootNode.getChildren().get(i);
+            node.setExpanded(true);
+            for (int j = 0; j < 2; j++) {
+                node.getChildren().add(new TreeItem<>("Sub Node " + i + "-" + j));
+            }
+        }
+
+        TreeTableColumn<String, String> column = new TreeTableColumn<>("Nodes");
+        column.setCellValueFactory(p -> new ReadOnlyStringWrapper(p.getValue().getValue()));
+        column.setPrefWidth(200);
+
+        TreeTableView<String> table = new TreeTableView<>(rootNode);
+        table.getColumns().add(column);
+
+        int selectIndex = 4; // select "Node 1"
+        int removeIndex = 2; // remove "Node 2"
+        table.getSelectionModel().select(selectIndex);
+        assertEquals(4, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 1", table.getSelectionModel().getSelectedItem().getValue());
+        table.getRoot().getChildren().remove(removeIndex);
+        assertEquals(4, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 1", table.getSelectionModel().getSelectedItem().getValue());
     }
 
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -630,7 +630,6 @@ public class TreeViewTest {
         assertEquals(mikeGraham, treeView.getFocusModel().getFocusedItem());
     }
 
-    @Ignore("Bug hasn't been fixed yet")
     @Test public void test_rt28114() {
         myCompanyRootNode.setExpanded(true);
         treeView.setRoot(myCompanyRootNode);
@@ -646,8 +645,6 @@ public class TreeViewTest {
         itSupport.getChildren().remove(mikeGraham);
         assertEquals(itSupport, treeView.getFocusModel().getFocusedItem());
         assertEquals(itSupport, treeView.getSelectionModel().getSelectedItem());
-        assertTrue(itSupport.isLeaf());
-        assertTrue(!itSupport.isExpanded());
     }
 
     @Test public void test_rt27820_1() {
@@ -3775,6 +3772,64 @@ public class TreeViewTest {
             assertFalse("cell must not be editing", cell.isEditing());
             assertNull("table editing must be cancelled by cell", treeView.getEditingItem());
         }
+    }
+
+    // JDK-8187596
+    @Test
+    public void testRemoveTreeItemShiftSelection() {
+        TreeItem<String> a, b, a1, a2, a3;
+        TreeItem<String> root = new TreeItem<>("root");
+        root.getChildren().addAll(
+                a = new TreeItem<>("a"),
+                b = new TreeItem<>("b")
+        );
+        root.setExpanded(true);
+
+        a.getChildren().addAll(
+                a1 = new TreeItem<>("a1"),
+                a2 = new TreeItem<>("a2"),
+                a3 = new TreeItem<>("a3")
+        );
+        a.setExpanded(true);
+
+        TreeView<String> stringTreeView = new TreeView<>(root);
+        stringTreeView.setShowRoot(false);
+        SelectionModel sm = stringTreeView.getSelectionModel();
+
+        sm.clearAndSelect(3); //select a3
+        assertEquals(a3, sm.getSelectedItem()); //verify
+        root.getChildren().remove(b); //remove b
+        //a3 should remain selected
+        assertEquals(3, sm.getSelectedIndex());
+        assertEquals(a3, sm.getSelectedItem());
+    }
+
+    // JDK-8193442
+    @Test
+    public void testRemoveTreeItemChangesSelectedItem() {
+        TreeItem<String> rootNode = new TreeItem<>("Root");
+        rootNode.setExpanded(true);
+        for (int i = 0; i < 3; i++) {
+            rootNode.getChildren().add(new TreeItem<>("Node " + i));
+        }
+        for (int i = 0; i < 2; i++) {
+            TreeItem<String> node = rootNode.getChildren().get(i);
+            node.setExpanded(true);
+            for (int j = 0; j < 2; j++) {
+                node.getChildren().add(new TreeItem<>("Sub Node " + i + "-" + j));
+            }
+        }
+
+        TreeView<String> table = new TreeView<>(rootNode);
+
+        int selectIndex = 4; // select "Node 1"
+        int removeIndex = 2; // remove "Node 2"
+        table.getSelectionModel().select(selectIndex);
+        assertEquals(4, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 1", table.getSelectionModel().getSelectedItem().getValue());
+        table.getRoot().getChildren().remove(removeIndex);
+        assertEquals(4, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 1", table.getSelectionModel().getSelectedItem().getValue());
     }
 
     public static class MisbehavingOnCancelTreeCell<S> extends TreeCell<S> {


### PR DESCRIPTION
clean backport of 8193442: Removing TreeItem from a TreeTableView sometime changes selectedItem

8187596: TreeView selection incorrectly changes after deleting an unselected row

Reviewed-by: aghaisas, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8193442](https://bugs.openjdk.org/browse/JDK-8193442): Removing TreeItem from a TreeTableView sometime changes selectedItem
 * [JDK-8187596](https://bugs.openjdk.org/browse/JDK-8187596): TreeView selection incorrectly changes after deleting an unselected row


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jfx17u pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/68.diff">https://git.openjdk.org/jfx17u/pull/68.diff</a>

</details>
