### PR TITLE
8286261: Selection of non-expanded non-leaf treeItem grows unexpectedly when adding two-level descendants

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
@@ -232,4 +232,18 @@ class ControlUtils {
         }
         return -1;
     }
+
+    public static <S> boolean isTreeItemIncludingAncestorsExpanded(TreeItem<S> item) {
+        if (item == null || !item.isExpanded()) {
+            return false;
+        }
+        TreeItem<S> ancestor = item.getParent();
+        while (ancestor != null) {
+            if (!ancestor.isExpanded()) {
+                return false;
+            }
+            ancestor = ancestor.getParent();
+        }
+        return true;
+    }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -2610,7 +2610,7 @@ public class TreeTableView<S> extends Control {
                         }
                     } else if (e.wasAdded()) {
                         // shuffle selection by the number of added items
-                        shift += treeItem.isExpanded() ? addedSize : 0;
+                        shift += ControlUtils.isTreeItemIncludingAncestorsExpanded(treeItem) ? addedSize : 0;
 
                         // RT-32963: We were taking the startRow from the TreeItem
                         // in which the children were added, rather than from the
@@ -2646,7 +2646,7 @@ public class TreeTableView<S> extends Control {
 
                         // shuffle selection by the number of removed items
                         // only if removed items are before the current selection.
-                        if (treeItem.isExpanded()) {
+                        if (ControlUtils.isTreeItemIncludingAncestorsExpanded(treeItem)) {
                             int lastSelectedSiblingIndex = selectedItems.stream()
                                     .map(item -> ControlUtils.getIndexOfChildWithDescendant(treeItem, item))
                                     .max(Comparator.naturalOrder())
@@ -3490,7 +3490,7 @@ public class TreeTableView<S> extends Control {
                         // get the TreeItem the event occurred on - we only need to
                         // shift if the tree item is expanded
                         TreeItem<S> eventTreeItem = e.getTreeItem();
-                        if (eventTreeItem.isExpanded()) {
+                        if (ControlUtils.isTreeItemIncludingAncestorsExpanded(eventTreeItem)) {
                             for (int i = 0; i < e.getAddedChildren().size(); i++) {
                                 // get the added item and determine the row it is in
                                 TreeItem<S> item = e.getAddedChildren().get(i);
@@ -3512,7 +3512,7 @@ public class TreeTableView<S> extends Control {
                             }
                         }
 
-                        if (e.getTreeItem().isExpanded()) {
+                        if (ControlUtils.isTreeItemIncludingAncestorsExpanded(e.getTreeItem())) {
                             int focusedSiblingRow = ControlUtils.getIndexOfChildWithDescendant(e.getTreeItem(), getFocusedItem());
                             if (e.getFrom() <= focusedSiblingRow) {
                                 // shuffle selection by the number of removed items

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
@@ -1398,7 +1398,7 @@ public class TreeView<T> extends Control {
                     // no-op
                 } else if (e.wasAdded()) {
                     // shuffle selection by the number of added items
-                    shift += treeItem.isExpanded() ? addedSize : 0;
+                    shift += ControlUtils.isTreeItemIncludingAncestorsExpanded(treeItem) ? addedSize : 0;
 
                     // RT-32963: We were taking the startRow from the TreeItem
                     // in which the children were added, rather than from the
@@ -1426,7 +1426,7 @@ public class TreeView<T> extends Control {
 
                     // shuffle selection by the number of removed items
                     // only if removed items are before the current selection.
-                    if (treeItem.isExpanded()) {
+                    if (ControlUtils.isTreeItemIncludingAncestorsExpanded(treeItem)) {
                         int lastSelectedSiblingIndex = selectedItems.stream()
                                 .map(item -> ControlUtils.getIndexOfChildWithDescendant(treeItem, item))
                                 .max(Comparator.naturalOrder())
@@ -1675,7 +1675,7 @@ public class TreeView<T> extends Control {
                         // get the TreeItem the event occurred on - we only need to
                         // shift if the tree item is expanded
                         TreeItem<T> eventTreeItem = e.getTreeItem();
-                        if (eventTreeItem.isExpanded()) {
+                        if (ControlUtils.isTreeItemIncludingAncestorsExpanded(eventTreeItem)) {
                             for (int i = 0; i < e.getAddedChildren().size(); i++) {
                                 // get the added item and determine the row it is in
                                 TreeItem<T> item = e.getAddedChildren().get(i);
@@ -1697,7 +1697,7 @@ public class TreeView<T> extends Control {
                             }
                         }
 
-                        if (e.getTreeItem().isExpanded()) {
+                        if (ControlUtils.isTreeItemIncludingAncestorsExpanded(e.getTreeItem())) {
                             int focusedSiblingRow = ControlUtils.getIndexOfChildWithDescendant(e.getTreeItem(), getFocusedItem());
                             if (e.getFrom() <= focusedSiblingRow) {
                                 // shuffle selection by the number of removed items

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -6832,4 +6832,87 @@ public class TreeTableViewTest {
         Thread.currentThread().setUncaughtExceptionHandler(exceptionHandler);
     }
 
+    // JDK-8286261
+    @Test
+    public void testAddTreeItemToCollapsedAncestorKeepsSelectedItem() {
+        TreeItem<String> rootNode = new TreeItem<>("Root");
+        rootNode.setExpanded(true);
+        TreeItem<String> level1 = new TreeItem<>("Node 0");
+        level1.setExpanded(false);
+        TreeItem<String> level2 = new TreeItem<>("Node 1");
+        level2.getChildren().add(new TreeItem<>("Node 2"));
+        level2.setExpanded(true);
+
+        rootNode.getChildren().add(level1);
+        rootNode.getChildren().add(new TreeItem<>("Node 3"));
+
+        level1.getChildren().add(level2);
+
+        TreeTableColumn<String, String> column = new TreeTableColumn<>("Nodes");
+        column.setCellValueFactory(p -> new ReadOnlyStringWrapper(p.getValue().getValue()));
+        column.setPrefWidth(200);
+
+        TreeTableView<String> table = new TreeTableView<>(rootNode);
+        table.setShowRoot(false);
+        table.getColumns().add(column);
+        table.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
+        table.getSelectionModel().select(level1);
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+
+        // add new node at level 3, that has a collapsed ancestor
+        level2.getChildren().add(new TreeItem<>("Node 4"));
+
+        // selection and focus remain at level1
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+    }
+
+    // JDK-8286261
+    @Test
+    public void testRemoveTreeItemFromCollapsedAncestorKeepsSelectedItem() {
+        TreeItem<String> rootNode = new TreeItem<>("Root");
+        rootNode.setExpanded(true);
+        TreeItem<String> level1 = new TreeItem<>("Node 0");
+        level1.setExpanded(false);
+        TreeItem<String> level2 = new TreeItem<>("Node 1");
+        level2.getChildren().add(new TreeItem<>("Node 2"));
+        level2.getChildren().add(new TreeItem<>("Node 3"));
+
+        level2.setExpanded(true);
+
+        rootNode.getChildren().add(level1);
+        rootNode.getChildren().add(new TreeItem<>("Node 4"));
+
+        level1.getChildren().add(level2);
+
+        TreeTableColumn<String, String> column = new TreeTableColumn<>("Nodes");
+        column.setCellValueFactory(p -> new ReadOnlyStringWrapper(p.getValue().getValue()));
+        column.setPrefWidth(200);
+
+        TreeTableView<String> table = new TreeTableView<>(rootNode);
+        table.setShowRoot(false);
+        table.getColumns().add(column);
+        table.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
+        table.getSelectionModel().select(level1);
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+
+        // remove Node 2 at level 3, that has a collapsed ancestor
+        level2.getChildren().remove(0);
+
+        // selection and focus remain at level1
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -3832,6 +3832,80 @@ public class TreeViewTest {
         assertEquals("Node 1", table.getSelectionModel().getSelectedItem().getValue());
     }
 
+    // JDK-8286261
+    @Test
+    public void testAddTreeItemToCollapsedAncestorKeepsSelectedItem() {
+        TreeItem<String> rootNode = new TreeItem<>("Root");
+        rootNode.setExpanded(true);
+        TreeItem<String> level1 = new TreeItem<>("Node 0");
+        level1.setExpanded(false);
+        TreeItem<String> level2 = new TreeItem<>("Node 1");
+        level2.getChildren().add(new TreeItem<>("Node 2"));
+        level2.setExpanded(true);
+
+        rootNode.getChildren().add(level1);
+        rootNode.getChildren().add(new TreeItem<>("Node 3"));
+
+        level1.getChildren().add(level2);
+
+        TreeView<String> table = new TreeView<>(rootNode);
+        table.setShowRoot(false);
+        table.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
+        table.getSelectionModel().select(level1);
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+
+        // add new node at level 3, that has a collapsed ancestor
+        level2.getChildren().add(new TreeItem<>("Node 4"));
+
+        // selection and focus remain at level1
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+    }
+
+    // JDK-8286261
+    @Test
+    public void testRemoveTreeItemFromCollapsedAncestorKeepsSelectedItem() {
+        TreeItem<String> rootNode = new TreeItem<>("Root");
+        rootNode.setExpanded(true);
+        TreeItem<String> level1 = new TreeItem<>("Node 0");
+        level1.setExpanded(false);
+        TreeItem<String> level2 = new TreeItem<>("Node 1");
+        level2.getChildren().add(new TreeItem<>("Node 2"));
+        level2.getChildren().add(new TreeItem<>("Node 3"));
+
+        level2.setExpanded(true);
+
+        rootNode.getChildren().add(level1);
+        rootNode.getChildren().add(new TreeItem<>("Node 4"));
+
+        level1.getChildren().add(level2);
+
+        TreeView<String> table = new TreeView<>(rootNode);
+        table.setShowRoot(false);
+        table.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
+        table.getSelectionModel().select(level1);
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+
+        // remove Node 2 at level 3, that has a collapsed ancestor
+        level2.getChildren().remove(0);
+
+        // selection and focus remain at level1
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+    }
+
     public static class MisbehavingOnCancelTreeCell<S> extends TreeCell<S> {
 
         @Override


### PR DESCRIPTION
8286261: Selection of non-expanded non-leaf treeItem grows unexpectedly when adding two-level descendants

Reviewed-by: aghaisas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286261](https://bugs.openjdk.org/browse/JDK-8286261): Selection of non-expanded non-leaf treeItem grows unexpectedly when adding two-level descendants


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.org/jfx17u pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/70.diff">https://git.openjdk.org/jfx17u/pull/70.diff</a>

</details>
