### PR TITLE
8284676: TreeTableView loses sort ordering when applied on empty table

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -582,10 +582,12 @@ public class TreeTableView<S> extends Control {
         @Override public Boolean call(TreeTableView table) {
             try {
                 TreeItem rootItem = table.getRoot();
-                if (rootItem == null || rootItem.getChildren().isEmpty()) return false;
+                if (rootItem == null) return false;
 
                 TreeSortMode sortMode = table.getSortMode();
                 if (sortMode == null) return false;
+
+                if (rootItem.getChildren().isEmpty()) return true;
 
                 rootItem.lastSortMode = sortMode;
                 rootItem.lastComparator = table.getComparator();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -786,6 +786,18 @@ public class TreeTableViewTest {
         });
     }
 
+    @Test public void testSetSortOrderRetainsWhenRootHasNoChildren() {
+        TreeTableView<String> ttv = new TreeTableView<>();
+        TreeItem<String> root = new TreeItem<>("root");
+        root.setExpanded(true);
+        ttv.setRoot(root);
+        assertEquals(0, ttv.getSortOrder().size());
+
+        TreeTableColumn<String, String> ttc = new TreeTableColumn<>("Column");
+        ttv.getSortOrder().add(ttc);
+        assertEquals(1, ttv.getSortOrder().size());
+    }
+
     @Test public void testNPEWhenRootItemIsNull() {
         TreeTableView<String> ttv = new TreeTableView<>();
         ControlTestUtils.runWithExceptionHandler(() -> {


### PR DESCRIPTION
Clean backport to `jfx17u`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284676](https://bugs.openjdk.org/browse/JDK-8284676): TreeTableView loses sort ordering when applied on empty table


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.org/jfx17u pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/76.diff">https://git.openjdk.org/jfx17u/pull/76.diff</a>

</details>
