### PR TITLE
8290348: TreeTableView jumping to top

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -3906,6 +3906,35 @@ public class TreeViewTest {
         assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
     }
 
+    private List<TreeItem<String>> generateChildren(int lvl) {
+        List<TreeItem<String>> children = new ArrayList<>();
+        for (int idx = 0; idx < 10; idx++) {
+            TreeItem<String> child = new TreeItem<>("Child lvl. " + lvl + " idx. " + idx);
+            child.setExpanded(true);
+            if (lvl <= 2) {
+                child.getChildren().addAll(generateChildren(lvl + 1));
+            }
+            children.add(child);
+        }
+        return children;
+    }
+
+    // JDK-8290348
+    @Test
+    public void testCheckPositionAfterCollapsed() {
+        TreeItem<String> rootNode = new TreeItem<>("Root");
+        rootNode.setExpanded(true);
+        rootNode.getChildren().addAll(generateChildren(1));
+        TreeView<String> treeView = new TreeView<>(rootNode);
+        treeView.scrollTo(100);
+        IndexedCell expandedCell = VirtualFlowTestUtils.getCell(treeView, 100);
+        Toolkit.getToolkit().firePulse();
+        rootNode.getChildren().get(1).setExpanded(false);
+        Toolkit.getToolkit().firePulse();
+        IndexedCell scrolledCell = VirtualFlowTestUtils.getCell(treeView, 100);
+        assertTrue(scrolledCell.isVisible());
+    }
+
     public static class MisbehavingOnCancelTreeCell<S> extends TreeCell<S> {
 
         @Override


### PR DESCRIPTION
Clean backport of 8290348: TreeTableView jumping to top
Reviewed-by: aghaisas, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290348](https://bugs.openjdk.org/browse/JDK-8290348): TreeTableView jumping to top


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.org/jfx17u pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/89.diff">https://git.openjdk.org/jfx17u/pull/89.diff</a>

</details>
