### PR TITLE
8222210: JFXPanel popups open at wrong coordinates when using multiple hidpi monitors

### DIFF
--- a/modules/javafx.graphics/src/main/java/module-info.java
+++ b/modules/javafx.graphics/src/main/java/module-info.java
@@ -68,6 +68,7 @@ module javafx.graphics {
 
     exports com.sun.glass.ui to
         javafx.media,
+        javafx.swing,
         javafx.web;
     exports com.sun.glass.utils to
         javafx.media,

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -38,6 +38,8 @@ import java.awt.Insets;
 import java.awt.EventQueue;
 import java.awt.SecondaryLoop;
 import java.awt.GraphicsEnvironment;
+import java.awt.GraphicsConfiguration;
+import java.awt.Rectangle;
 import java.awt.event.AWTEventListener;
 import java.awt.event.ComponentEvent;
 import java.awt.event.FocusEvent;
@@ -48,6 +50,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.InvocationEvent;
+import java.awt.geom.AffineTransform;
 import java.awt.im.InputMethodRequests;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
@@ -59,7 +62,9 @@ import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
 
 import javafx.application.Platform;
+import javafx.geometry.Point2D;
 import javafx.scene.Scene;
+import com.sun.glass.ui.Screen;
 
 import com.sun.javafx.application.PlatformImpl;
 import com.sun.javafx.cursor.CursorFrame;
@@ -362,6 +367,44 @@ public class JFXPanel extends JComponent {
         return false;
     }
 
+    // we need to know the JavaFX screen of the current AWT graphcisConfiguration
+    private Screen findScreen(GraphicsConfiguration graphicsConfiguration) {
+        Rectangle awtBounds = graphicsConfiguration.getBounds();
+        AffineTransform awtScales = graphicsConfiguration.getDefaultTransform();
+        for (Screen screen : Screen.getScreens()) {
+            if ((Math.abs(screen.getPlatformX() - awtBounds.getX()) < 2.) &&
+                    (Math.abs(screen.getPlatformY() - awtBounds.getY()) < 2.) &&
+                    (Math.abs(screen.getPlatformWidth() - awtScales.getScaleX() * awtBounds.getWidth()) < 2.) &&
+                    (Math.abs(screen.getPlatformHeight() - awtScales.getScaleY() * awtBounds.getHeight()) < 2.)) {
+                return screen;
+            }
+        }
+        return null;
+    }
+
+    private Point2D convertSwingToFxPixel(GraphicsConfiguration g, double wx, double wy) {
+        double newx, newy;
+        Screen screen = findScreen(g);
+        if (screen != null) {
+            AffineTransform awtScales = getGraphicsConfiguration().getDefaultTransform();
+            float pScaleX = screen.getPlatformScaleX();
+            float pScaleY = screen.getPlatformScaleY();
+            int sx = screen.getX();
+            int sy = screen.getY();
+            double awtScaleX = awtScales.getScaleX();
+            double awtScaleY = awtScales.getScaleY();
+
+            int px = screen.getPlatformX();
+            int py = screen.getPlatformY();
+            newx = sx + (wx - px) * awtScaleX / pScaleX;
+            newy = sy + (wy - py) * awtScaleY / pScaleY;
+        } else {
+            newx = wx;
+            newy = wy;
+        }
+        return new Point2D(newx, newy);
+    }
+
     private void sendMouseEventToFX(MouseEvent e) {
         if (scenePeer == null || !isFxEnabled()) {
             return;
@@ -407,6 +450,9 @@ public class JFXPanel extends JComponent {
         if (e.getID() == MouseEvent.MOUSE_PRESSED || e.getID() == MouseEvent.MOUSE_RELEASED) {
             popupTrigger = e.isPopupTrigger();
         }
+        Point2D onScreen = convertSwingToFxPixel(getGraphicsConfiguration(), e.getXOnScreen(), e.getYOnScreen());
+        int fxXOnScreen = (int)Math.round(onScreen.getX());
+        int fxYOnScreen = (int)Math.round(onScreen.getY());
 
         if(e.getID() == MouseEvent.MOUSE_WHEEL) {
             scenePeer.scrollEvent(AbstractEvents.MOUSEEVENT_VERTICAL_WHEEL,
@@ -414,7 +460,7 @@ public class JFXPanel extends JComponent {
                     0, 0, // total scroll
                     40, 40, // multiplier
                     e.getX(), e.getY(),
-                    e.getXOnScreen(), e.getYOnScreen(),
+                    fxXOnScreen, fxYOnScreen,
                     (extModifiers & MouseEvent.SHIFT_DOWN_MASK) != 0,
                     (extModifiers & MouseEvent.CTRL_DOWN_MASK) != 0,
                     (extModifiers & MouseEvent.ALT_DOWN_MASK) != 0,
@@ -425,7 +471,8 @@ public class JFXPanel extends JComponent {
                     SwingEvents.mouseButtonToEmbedMouseButton(e.getButton(), extModifiers),
                     primaryBtnDown, middleBtnDown, secondaryBtnDown,
                     backBtnDown, forwardBtnDown,
-                    e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(),
+                    e.getX(), e.getY(),
+                    fxXOnScreen, fxYOnScreen,
                     (extModifiers & MouseEvent.SHIFT_DOWN_MASK) != 0,
                     (extModifiers & MouseEvent.CTRL_DOWN_MASK) != 0,
                     (extModifiers & MouseEvent.ALT_DOWN_MASK) != 0,
@@ -433,7 +480,7 @@ public class JFXPanel extends JComponent {
                     popupTrigger);
         }
         if (e.isPopupTrigger()) {
-            scenePeer.menuEvent(e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(), false);
+            scenePeer.menuEvent(e.getX(), e.getY(), fxXOnScreen, fxYOnScreen, false);
         }
     }
 
@@ -598,8 +645,9 @@ public class JFXPanel extends JComponent {
         synchronized (getTreeLock()) {
             if (isShowing()) {
                 Point p = getLocationOnScreen();
-                screenX = p.x;
-                screenY = p.y;
+                Point2D fxcoord = convertSwingToFxPixel(getGraphicsConfiguration(), p.x, p.y);
+                screenX = (int)Math.round(fxcoord.getX());
+                screenY = (int)Math.round(fxcoord.getY());
                 return true;
             }
         }


### PR DESCRIPTION
8222210: JFXPanel popups open at wrong coordinates when using multiple hidpi monitors

Reviewed-by: kcr, angorya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8222210](https://bugs.openjdk.org/browse/JDK-8222210): JFXPanel popups open at wrong coordinates when using multiple hidpi monitors


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/jfx17u pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/90.diff">https://git.openjdk.org/jfx17u/pull/90.diff</a>

</details>
