### PR TITLE
8087557: [Win] [Accessibility, Dialogs] Alert Dialog content is not fully read by Screen Reader

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
@@ -53,6 +53,7 @@ import javafx.css.StyleableProperty;
 import javafx.css.StyleableStringProperty;
 import javafx.event.ActionEvent;
 import javafx.geometry.Pos;
+import javafx.scene.AccessibleRole;
 import javafx.scene.Node;
 import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.image.Image;
@@ -209,6 +210,7 @@ public class DialogPane extends Pane {
      */
     public DialogPane() {
         getStyleClass().add("dialog-pane");
+        setAccessibleRole(AccessibleRole.DIALOG);
 
         headerTextPanel = new GridPane();
         getChildren().add(headerTextPanel);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogTest.java
@@ -24,7 +24,6 @@
  */
 package test.javafx.scene.control;
 
-import com.sun.javafx.tk.Toolkit;
 import javafx.scene.AccessibleRole;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.scene.control;
+
+import com.sun.javafx.tk.Toolkit;
+import javafx.scene.AccessibleRole;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+/** Tests for the {@link Dialog} class. */
+public class DialogTest {
+
+    private Dialog<ButtonType> dialog;
+
+    @Before
+    public void setUp() {
+        dialog = new Dialog<>();
+    }
+
+    @After
+    public void cleanUp() {
+        // Set a dummy result so the dialog can be closed.
+        dialog.setResult(new ButtonType(""));
+        dialog.hide();
+    }
+
+    @Test
+    public void testAccessibleRole() {
+        assertEquals(AccessibleRole.DIALOG, dialog.getDialogPane().getAccessibleRole());
+    }
+}
+

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
@@ -1299,6 +1299,7 @@ final class MacAccessible extends Accessible {
                         case PAGE_ITEM: result = "page"; break;
                         case TAB_ITEM: result = "tab"; break;
                         case LIST_VIEW: result = "list"; break;
+                        case DIALOG: result = "dialog"; break;
                         default:
                             MacRole macRole = getRole(role);
                             MacSubrole subRole = MacSubrole.getRole(role);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
@@ -101,6 +101,7 @@ final class WinAccessible extends Accessible {
     private static final int UIA_ToggleToggleStatePropertyId     = 30086;
     private static final int UIA_AriaRolePropertyId              = 30101;
     private static final int UIA_ProviderDescriptionPropertyId   = 30107;
+    private static final int UIA_IsDialogPropertyId              = 30174;
 
     /* Control Pattern Identifiers */
     private static final int UIA_InvokePatternId                 = 10000;
@@ -791,6 +792,7 @@ final class WinAccessible extends Accessible {
                     switch (role) {
                         case TITLED_PANE: description = "title pane"; break;
                         case PAGE_ITEM: description = "page"; break;
+                        case DIALOG: description = "dialog"; break;
                         default:
                     }
                 }
@@ -830,6 +832,12 @@ final class WinAccessible extends Accessible {
                 variant.boolVal = focus != null ? focus : false;
                 break;
             }
+            case UIA_IsDialogPropertyId: {
+                AccessibleRole role = (AccessibleRole) getAttribute(ROLE);
+                variant = new WinVariant();
+                variant.vt = WinVariant.VT_BOOL;
+                variant.boolVal = (role == AccessibleRole.DIALOG);
+            } break;
             case UIA_IsContentElementPropertyId:
             case UIA_IsControlElementPropertyId: {
                 //TODO how to handle ControlElement versus ContentElement

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
@@ -822,4 +822,18 @@ public enum AccessibleRole {
      * </ul>
      */
     TREE_VIEW,
+
+    /**
+     * Dialog role.
+     * <p>
+     * Attributes:
+     * <ul>
+     * <li> {@link AccessibleAttribute#TEXT} </li>
+     * <li> {@link AccessibleAttribute#ROLE_DESCRIPTION} </li>
+     * <li> {@link AccessibleAttribute#CHILDREN} </li>
+     * </ul>
+     *
+     * @since 20
+     */
+    DIALOG
 }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
@@ -833,7 +833,7 @@ public enum AccessibleRole {
      * <li> {@link AccessibleAttribute#CHILDREN} </li>
      * </ul>
      *
-     * @since 20
+     * @since 17.0.6
      */
     DIALOG
 }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -6508,7 +6508,13 @@ public class Scene implements EventTarget {
                             }
                             return getRoot();//not sure
                         }
-                        case ROLE: return AccessibleRole.PARENT;
+                        case ROLE: {
+                            if (getRoot() != null && getRoot().getAccessibleRole() == AccessibleRole.DIALOG) {
+                                return AccessibleRole.DIALOG;
+                            } else {
+                                return AccessibleRole.PARENT;
+                            }
+                        }
                         case SCENE: return Scene.this;
                         case FOCUS_NODE: {
                             if (transientFocusContainer != null) {


### PR DESCRIPTION
Backport this a11y fix to jfx17u.
This is not a clean backport. The source code changes apply cleanly but there was a conflict in test file.
The test `DialogTest.java` file does not exist in jfx17u source.
The file is now added but only with one test that was added as part of this fix to mainline, and other pre-existing tests are removed.
Tested that fix works as expected on Windows and macOS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8087557](https://bugs.openjdk.org/browse/JDK-8087557): [Win] [Accessibility, Dialogs] Alert Dialog content is not fully read by Screen Reader


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.org/jfx17u pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/91.diff">https://git.openjdk.org/jfx17u/pull/91.diff</a>

</details>
