### PR TITLE
8289542: Update JPEG Image Decoding Software to 9e

### DIFF
--- a/modules/javafx.graphics/src/main/legal/jpeg_fx.md
+++ b/modules/javafx.graphics/src/main/legal/jpeg_fx.md
@@ -1,4 +1,4 @@
-## Independent JPEG Group (IJG) JPEG v9d
+## Independent JPEG Group (IJG) JPEG v9e
 
 ### IJG License
 ```
@@ -18,7 +18,7 @@ with respect to this software, its quality, accuracy, merchantability, or
 fitness for a particular purpose.  This software is provided "AS IS", and you,
 its user, assume the entire risk as to its quality and accuracy.
 
-This software is copyright (C) 1991-2020, Thomas G. Lane, Guido Vollbeding.
+This software is copyright (C) 1991-2022, Thomas G. Lane, Guido Vollbeding.
 All Rights Reserved except as specified below.
 
 Permission is hereby granted to use, copy, modify, and distribute this

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/README
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/README
@@ -1,7 +1,7 @@
 The Independent JPEG Group's JPEG software
 ==========================================
 
-README for release 9d of 12-Jan-2020
+README for release 9e of 16-Jan-2022
 ====================================
 
 This distribution contains the ninth public release of the Independent JPEG
@@ -38,6 +38,7 @@ User documentation:
                     rdjpgcom, and wrjpgcom.
   *.1               Unix-style man pages for programs (same info as usage.txt).
   wizard.txt        Advanced usage instructions for JPEG wizards only.
+  cdaltui.txt       Description of alternate user interface for cjpeg/djpeg.
   change.log        Version-to-version change highlights.
 Programmer and internal documentation:
   libjpeg.txt       How to use the JPEG library in your own programs.
@@ -115,7 +116,7 @@ with respect to this software, its quality, accuracy, merchantability, or
 fitness for a particular purpose.  This software is provided "AS IS", and you,
 its user, assume the entire risk as to its quality and accuracy.
 
-This software is copyright (C) 1991-2020, Thomas G. Lane, Guido Vollbeding.
+This software is copyright (C) 1991-2022, Thomas G. Lane, Guido Vollbeding.
 All Rights Reserved except as specified below.
 
 Permission is hereby granted to use, copy, modify, and distribute this
@@ -165,7 +166,7 @@ The best short technical introduction to the JPEG compression algorithm is
 (Adjacent articles in that issue discuss MPEG motion picture compression,
 applications of JPEG, and related topics.)  If you don't have the CACM issue
 handy, a PDF file containing a revised version of Wallace's article is
-available at http://www.ijg.org/files/Wallace.JPEG.pdf.  The file (actually
+available at https://www.ijg.org/files/Wallace.JPEG.pdf.  The file (actually
 a preprint for an article that appeared in IEEE Trans. Consumer Electronics)
 omits the sample images that appeared in CACM, but it includes corrections
 and some added material.  Note: the Wallace article is copyright ACM and IEEE,
@@ -209,17 +210,16 @@ document is Revision 3.  And a contributed document ISO/IEC JTC1/SC29/WG1 N
 5799 with title "Evolution of JPEG", June/July 2011, Berlin, Germany.
 IJG JPEG 9 introduces a reversible color transform for improved lossless
 compression which is described in a contributed document ISO/IEC JTC1/SC29/
-WG1 N 6080 with title "JPEG 9 Lossless Coding", June/July 2012, Paris,
-France.
+WG1 N 6080 with title "JPEG 9 Lossless Coding", June/July 2012, Paris, France.
 
 The JPEG standard does not specify all details of an interchangeable file
 format.  For the omitted details we follow the "JFIF" conventions, version 2.
 JFIF version 1 has been adopted as Recommendation ITU-T T.871 (05/2011) :
 Information technology - Digital compression and coding of continuous-tone
 still images: JPEG File Interchange Format (JFIF).  It is available as a
-free download in PDF file format from http://www.itu.int/rec/T-REC-T.871.
+free download in PDF file format from https://www.itu.int/rec/T-REC-T.871.
 A PDF file of the older JFIF document is available at
-http://www.w3.org/Graphics/JPEG/jfif3.pdf.
+https://www.w3.org/Graphics/JPEG/jfif3.pdf.
 
 The TIFF 6.0 file format specification can be obtained by FTP from
 ftp://ftp.sgi.com/graphics/tiff/TIFF6.ps.gz.  The JPEG incorporation scheme
@@ -227,7 +227,7 @@ found in the TIFF 6.0 spec of 3-June-92 has a number of serious problems.
 IJG does not recommend use of the TIFF 6.0 design (TIFF Compression tag 6).
 Instead, we recommend the JPEG design proposed by TIFF Technical Note #2
 (Compression tag 7).  Copies of this Note can be obtained from
-http://www.ijg.org/files/.  It is expected that the next revision
+https://www.ijg.org/files/.  It is expected that the next revision
 of the TIFF spec will replace the 6.0 JPEG design with the Note's design.
 Although IJG's own code does not support TIFF/JPEG, the free libtiff library
 uses our library to implement TIFF/JPEG per the Note.
@@ -238,9 +238,11 @@ ARCHIVE LOCATIONS
 
 The "official" archive site for this software is www.ijg.org.
 The most recent released version can always be found there in
-directory "files".  This particular version will be archived as
-http://www.ijg.org/files/jpegsrc.v9d.tar.gz, and in Windows-compatible
-"zip" archive format as http://www.ijg.org/files/jpegsr9d.zip.
+directory "files".  This particular version will be archived
+in Windows-compatible "zip" archive format as
+https://www.ijg.org/files/jpegsr9e.zip, and
+in Unix-compatible "tar.gz" archive format as
+https://www.ijg.org/files/jpegsrc.v9e.tar.gz.
 
 The JPEG FAQ (Frequently Asked Questions) article is a source of some
 general information about JPEG.
@@ -286,11 +288,12 @@ communication about JPEG configuration in Sigma Photo Pro software.
 
 Thank to Andrew Finkenstadt for hosting the ijg.org site.
 
-Thank to Thomas G. Lane for the original design and development of
-this singular software package.
+Thank to Thomas G. Lane for the original design and development
+of this singular software package.
 
-Thank to Lars Goehler, Andreas Heinecke, Sebastian Fuss, Yvonne Roebert,
-Andrej Werner, and Ulf-Dietrich Braumann for support and public relations.
+Thank to Lars Goehler, Andreas Heinecke, Sebastian Fuss,
+Yvonne Roebert, Andrej Werner, Ulf-Dietrich Braumann,
+and Nina Ssymank for support and public relations.
 
 
 FILE FORMAT WARS

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jccoefct.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jccoefct.c
@@ -2,7 +2,7 @@
  * jccoefct.c
  *
  * Copyright (C) 1994-1997, Thomas G. Lane.
- * Modified 2003-2011 by Guido Vollbeding.
+ * Modified 2003-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -36,16 +36,14 @@ typedef struct {
   struct jpeg_c_coef_controller pub; /* public fields */
 
   JDIMENSION iMCU_row_num;    /* iMCU row # within image */
-  JDIMENSION mcu_ctr;        /* counts MCUs processed in current row */
+  JDIMENSION MCU_ctr;        /* counts MCUs processed in current row */
   int MCU_vert_offset;        /* counts MCU rows within iMCU row */
   int MCU_rows_per_iMCU_row;    /* number of such rows needed */
 
   /* For single-pass compression, it's sufficient to buffer just one MCU
-   * (although this may prove a bit slow in practice).  We allocate a
-   * workspace of C_MAX_BLOCKS_IN_MCU coefficient blocks, and reuse it for each
-   * MCU constructed and sent.  (On 80x86, the workspace is FAR even though
-   * it's not really very big; this is to keep the module interfaces unchanged
-   * when a large coefficient buffer is necessary.)
+   * (although this may prove a bit slow in practice).  We append a
+   * workspace of C_MAX_BLOCKS_IN_MCU coefficient blocks, and reuse it
+   * for each MCU constructed and sent.
    * In multi-pass modes, this array points to the current MCU's blocks
    * within the virtual arrays.
    */
@@ -53,6 +51,9 @@ typedef struct {
 
   /* In multi-pass modes, we need a virtual block array for each component. */
   jvirt_barray_ptr whole_image[MAX_COMPONENTS];
+
+  /* Workspace for single-pass compression (omitted otherwise). */
+  JBLOCK blk_buffer[C_MAX_BLOCKS_IN_MCU];
 } my_coef_controller;
 
 typedef my_coef_controller * my_coef_ptr;
@@ -88,7 +89,7 @@ start_iMCU_row (j_compress_ptr cinfo)
       coef->MCU_rows_per_iMCU_row = cinfo->cur_comp_info[0]->last_row_height;
   }
 
-  coef->mcu_ctr = 0;
+  coef->MCU_ctr = 0;
   coef->MCU_vert_offset = 0;
 }
 
@@ -125,7 +126,6 @@ start_pass_coef (j_compress_ptr cinfo, J_BUF_MODE pass_mode)
 #endif
   default:
     ERREXIT(cinfo, JERR_BAD_BUFFER_MODE);
-    break;
   }
 }
 
@@ -147,59 +147,56 @@ compress_data (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
   JDIMENSION MCU_col_num;    /* index of current MCU within row */
   JDIMENSION last_MCU_col = cinfo->MCUs_per_row - 1;
   JDIMENSION last_iMCU_row = cinfo->total_iMCU_rows - 1;
-  int blkn, bi, ci, yindex, yoffset, blockcnt;
-  JDIMENSION ypos, xpos;
+  int ci, xindex, yindex, yoffset, blockcnt;
+  JBLOCKROW blkp;
+  JSAMPARRAY input_ptr;
+  JDIMENSION xpos;
   jpeg_component_info *compptr;
   forward_DCT_ptr forward_DCT;
 
   /* Loop to write as much as one whole iMCU row */
   for (yoffset = coef->MCU_vert_offset; yoffset < coef->MCU_rows_per_iMCU_row;
        yoffset++) {
-    for (MCU_col_num = coef->mcu_ctr; MCU_col_num <= last_MCU_col;
+    for (MCU_col_num = coef->MCU_ctr; MCU_col_num <= last_MCU_col;
      MCU_col_num++) {
       /* Determine where data comes from in input_buf and do the DCT thing.
-       * Each call on forward_DCT processes a horizontal row of DCT blocks
-       * as wide as an MCU; we rely on having allocated the MCU_buffer[] blocks
-       * sequentially.  Dummy blocks at the right or bottom edge are filled in
+       * Each call on forward_DCT processes a horizontal row of DCT blocks as
+       * wide as an MCU.  Dummy blocks at the right or bottom edge are filled in
        * specially.  The data in them does not matter for image reconstruction,
        * so we fill them with values that will encode to the smallest amount of
        * data, viz: all zeroes in the AC entries, DC entries equal to previous
        * block's DC value.  (Thanks to Thomas Kinsman for this idea.)
        */
-      blkn = 0;
+      blkp = coef->blk_buffer;    /* pointer to current DCT block within MCU */
       for (ci = 0; ci < cinfo->comps_in_scan; ci++) {
     compptr = cinfo->cur_comp_info[ci];
     forward_DCT = cinfo->fdct->forward_DCT[compptr->component_index];
+    input_ptr = input_buf[compptr->component_index] +
+      yoffset * compptr->DCT_v_scaled_size;
+    /* ypos == (yoffset + yindex) * compptr->DCT_v_scaled_size */
     blockcnt = (MCU_col_num < last_MCU_col) ? compptr->MCU_width
                         : compptr->last_col_width;
     xpos = MCU_col_num * compptr->MCU_sample_width;
-    ypos = yoffset * compptr->DCT_v_scaled_size;
-    /* ypos == (yoffset+yindex) * DCTSIZE */
     for (yindex = 0; yindex < compptr->MCU_height; yindex++) {
       if (coef->iMCU_row_num < last_iMCU_row ||
-          yoffset+yindex < compptr->last_row_height) {
-        (*forward_DCT) (cinfo, compptr,
-                input_buf[compptr->component_index],
-                coef->MCU_buffer[blkn],
-                ypos, xpos, (JDIMENSION) blockcnt);
-        if (blockcnt < compptr->MCU_width) {
-          /* Create some dummy blocks at the right edge of the image. */
-          FMEMZERO((void FAR *) coef->MCU_buffer[blkn + blockcnt],
-               (compptr->MCU_width - blockcnt) * SIZEOF(JBLOCK));
-          for (bi = blockcnt; bi < compptr->MCU_width; bi++) {
-        coef->MCU_buffer[blkn+bi][0][0] = coef->MCU_buffer[blkn+bi-1][0][0];
-          }
-        }
+          yoffset + yindex < compptr->last_row_height) {
+        (*forward_DCT) (cinfo, compptr, input_ptr, blkp,
+                xpos, (JDIMENSION) blockcnt);
+        input_ptr += compptr->DCT_v_scaled_size;
+        blkp += blockcnt;
+        /* Dummy blocks at right edge */
+        if ((xindex = compptr->MCU_width - blockcnt) == 0)
+          continue;
       } else {
-        /* Create a row of dummy blocks at the bottom of the image. */
-        FMEMZERO((void FAR *) coef->MCU_buffer[blkn],
-             compptr->MCU_width * SIZEOF(JBLOCK));
-        for (bi = 0; bi < compptr->MCU_width; bi++) {
-          coef->MCU_buffer[blkn+bi][0][0] = coef->MCU_buffer[blkn-1][0][0];
-        }
+        /* At bottom of image, need a whole row of dummy blocks */
+        xindex = compptr->MCU_width;
       }
-      blkn += compptr->MCU_width;
-      ypos += compptr->DCT_v_scaled_size;
+      /* Fill in any dummy blocks needed in this row */
+      MEMZERO(blkp, xindex * SIZEOF(JBLOCK));
+      do {
+        blkp[0][0] = blkp[-1][0];
+        blkp++;
+      } while (--xindex);
     }
       }
       /* Try to write the MCU.  In event of a suspension failure, we will
@@ -208,12 +205,12 @@ compress_data (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
       if (! (*cinfo->entropy->encode_mcu) (cinfo, coef->MCU_buffer)) {
     /* Suspension forced; update state counters and exit */
     coef->MCU_vert_offset = yoffset;
-    coef->mcu_ctr = MCU_col_num;
+    coef->MCU_ctr = MCU_col_num;
     return FALSE;
       }
     }
     /* Completed an MCU row, but perhaps not an iMCU row */
-    coef->mcu_ctr = 0;
+    coef->MCU_ctr = 0;
   }
   /* Completed the iMCU row, advance counters for next one */
   coef->iMCU_row_num++;
@@ -256,6 +253,7 @@ compress_first_pass (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
   jpeg_component_info *compptr;
   JBLOCKARRAY buffer;
   JBLOCKROW thisblockrow, lastblockrow;
+  JSAMPARRAY input_ptr;
   forward_DCT_ptr forward_DCT;
 
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
@@ -280,14 +278,15 @@ compress_first_pass (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
     if (ndummy > 0)
       ndummy = h_samp_factor - ndummy;
     forward_DCT = cinfo->fdct->forward_DCT[ci];
+    input_ptr = input_buf[ci];
     /* Perform DCT for all non-dummy blocks in this iMCU row.  Each call
      * on forward_DCT processes a complete horizontal row of DCT blocks.
      */
     for (block_row = 0; block_row < block_rows; block_row++) {
       thisblockrow = buffer[block_row];
-      (*forward_DCT) (cinfo, compptr, input_buf[ci], thisblockrow,
-              (JDIMENSION) (block_row * compptr->DCT_v_scaled_size),
+      (*forward_DCT) (cinfo, compptr, input_ptr, thisblockrow,
               (JDIMENSION) 0, blocks_across);
+      input_ptr += compptr->DCT_v_scaled_size;
       if (ndummy > 0) {
     /* Create dummy blocks at the right edge of the image. */
     thisblockrow += blocks_across; /* => first dummy block */
@@ -303,15 +302,14 @@ compress_first_pass (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
      * of the dummy blocks to match the last real block's DC value.
      * This squeezes a few more bytes out of the resulting file...
      */
-    if (coef->iMCU_row_num == last_iMCU_row) {
+    if (block_row < compptr->v_samp_factor) {
       blocks_across += ndummy;    /* include lower right corner */
       MCUs_across = blocks_across / h_samp_factor;
-      for (block_row = block_rows; block_row < compptr->v_samp_factor;
-       block_row++) {
+      do {
     thisblockrow = buffer[block_row];
     lastblockrow = buffer[block_row-1];
     FMEMZERO((void FAR *) thisblockrow,
-         (size_t) (blocks_across * SIZEOF(JBLOCK)));
+         (size_t) blocks_across * SIZEOF(JBLOCK));
     for (MCUindex = 0; MCUindex < MCUs_across; MCUindex++) {
       lastDC = lastblockrow[h_samp_factor-1][0];
       for (bi = 0; bi < h_samp_factor; bi++) {
@@ -320,7 +318,7 @@ compress_first_pass (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
       thisblockrow += h_samp_factor; /* advance to next MCU in row */
       lastblockrow += h_samp_factor;
     }
-      }
+      } while (++block_row < compptr->v_samp_factor);
     }
   }
   /* NB: compress_output will increment iMCU_row_num if successful.
@@ -347,8 +345,9 @@ compress_output (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
 {
   my_coef_ptr coef = (my_coef_ptr) cinfo->coef;
   JDIMENSION MCU_col_num;    /* index of current MCU within row */
-  int blkn, ci, xindex, yindex, yoffset;
+  int ci, xindex, yindex, yoffset;
   JDIMENSION start_col;
+  JBLOCKARRAY blkp;
   JBLOCKARRAY buffer[MAX_COMPS_IN_SCAN];
   JBLOCKROW buffer_ptr;
   jpeg_component_info *compptr;
@@ -368,30 +367,31 @@ compress_output (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
   /* Loop to process one whole iMCU row */
   for (yoffset = coef->MCU_vert_offset; yoffset < coef->MCU_rows_per_iMCU_row;
        yoffset++) {
-    for (MCU_col_num = coef->mcu_ctr; MCU_col_num < cinfo->MCUs_per_row;
+    for (MCU_col_num = coef->MCU_ctr; MCU_col_num < cinfo->MCUs_per_row;
      MCU_col_num++) {
       /* Construct list of pointers to DCT blocks belonging to this MCU */
-      blkn = 0;            /* index of current DCT block within MCU */
+      blkp = coef->MCU_buffer;    /* pointer to current DCT block within MCU */
       for (ci = 0; ci < cinfo->comps_in_scan; ci++) {
     compptr = cinfo->cur_comp_info[ci];
     start_col = MCU_col_num * compptr->MCU_width;
     for (yindex = 0; yindex < compptr->MCU_height; yindex++) {
-      buffer_ptr = buffer[ci][yindex+yoffset] + start_col;
-      for (xindex = 0; xindex < compptr->MCU_width; xindex++) {
-        coef->MCU_buffer[blkn++] = buffer_ptr++;
-      }
+      buffer_ptr = buffer[ci][yoffset + yindex] + start_col;
+      xindex = compptr->MCU_width;
+      do {
+        *blkp++ = buffer_ptr++;
+      } while (--xindex);
     }
       }
       /* Try to write the MCU. */
       if (! (*cinfo->entropy->encode_mcu) (cinfo, coef->MCU_buffer)) {
     /* Suspension forced; update state counters and exit */
     coef->MCU_vert_offset = yoffset;
-    coef->mcu_ctr = MCU_col_num;
+    coef->MCU_ctr = MCU_col_num;
     return FALSE;
       }
     }
     /* Completed an MCU row, but perhaps not an iMCU row */
-    coef->mcu_ctr = 0;
+    coef->MCU_ctr = 0;
   }
   /* Completed the iMCU row, advance counters for next one */
   coef->iMCU_row_num++;
@@ -411,13 +411,6 @@ jinit_c_coef_controller (j_compress_ptr cinfo, boolean need_full_buffer)
 {
   my_coef_ptr coef;
 
-  coef = (my_coef_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(my_coef_controller));
-  cinfo->coef = (struct jpeg_c_coef_controller *) coef;
-  coef->pub.start_pass = start_pass_coef;
-
-  /* Create the coefficient buffer. */
   if (need_full_buffer) {
 #ifdef FULL_COEF_BUFFER_SUPPORTED
     /* Allocate a full-image virtual array for each component, */
@@ -425,6 +418,9 @@ jinit_c_coef_controller (j_compress_ptr cinfo, boolean need_full_buffer)
     int ci;
     jpeg_component_info *compptr;
 
+    coef = (my_coef_ptr) (*cinfo->mem->alloc_small)
+      ((j_common_ptr) cinfo, JPOOL_IMAGE,
+       SIZEOF(my_coef_controller) - SIZEOF(coef->blk_buffer));
     for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
      ci++, compptr++) {
       coef->whole_image[ci] = (*cinfo->mem->request_virt_barray)
@@ -440,15 +436,21 @@ jinit_c_coef_controller (j_compress_ptr cinfo, boolean need_full_buffer)
 #endif
   } else {
     /* We only need a single-MCU buffer. */
-    JBLOCKROW buffer;
-    int i;
+    JBLOCKARRAY blkp;
+    JBLOCKROW buffer_ptr;
+    int bi;
 
-    buffer = (JBLOCKROW)
-      (*cinfo->mem->alloc_large) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                  C_MAX_BLOCKS_IN_MCU * SIZEOF(JBLOCK));
-    for (i = 0; i < C_MAX_BLOCKS_IN_MCU; i++) {
-      coef->MCU_buffer[i] = buffer + i;
-    }
+    coef = (my_coef_ptr) (*cinfo->mem->alloc_small)
+      ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_coef_controller));
+    blkp = coef->MCU_buffer;
+    buffer_ptr = coef->blk_buffer;
+    bi = C_MAX_BLOCKS_IN_MCU;
+    do {
+      *blkp++ = buffer_ptr++;
+    } while (--bi);
     coef->whole_image[0] = NULL; /* flag for no virtual arrays */
   }
+
+  coef->pub.start_pass = start_pass_coef;
+  cinfo->coef = &coef->pub;
 }

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jcdctmgr.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jcdctmgr.c
@@ -2,7 +2,7 @@
  * jcdctmgr.c
  *
  * Copyright (C) 1994-1996, Thomas G. Lane.
- * Modified 2003-2013 by Guido Vollbeding.
+ * Modified 2003-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -66,15 +66,14 @@ typedef union {
  * Perform forward DCT on one or more blocks of a component.
  *
  * The input samples are taken from the sample_data[] array starting at
- * position start_row/start_col, and moving to the right for any additional
- * blocks. The quantized coefficients are returned in coef_blocks[].
+ * position start_col, and moving to the right for any additional blocks.
+ * The quantized coefficients are returned in coef_blocks[].
  */
 
 METHODDEF(void)
 forward_DCT (j_compress_ptr cinfo, jpeg_component_info * compptr,
          JSAMPARRAY sample_data, JBLOCKROW coef_blocks,
-         JDIMENSION start_row, JDIMENSION start_col,
-         JDIMENSION num_blocks)
+         JDIMENSION start_col, JDIMENSION num_blocks)
 /* This version is used for integer DCT implementations. */
 {
   /* This routine is heavily used, so it's worth coding it tightly. */
@@ -83,8 +82,6 @@ forward_DCT (j_compress_ptr cinfo, jpeg_component_info * compptr,
   DCTELEM * divisors = (DCTELEM *) compptr->dct_table;
   DCTELEM workspace[DCTSIZE2];    /* work area for FDCT subroutine */
   JDIMENSION bi;
-
-  sample_data += start_row;    /* fold in the vertical offset once */
 
   for (bi = 0; bi < num_blocks; bi++, start_col += compptr->DCT_h_scaled_size) {
     /* Perform the DCT */
@@ -136,8 +133,7 @@ forward_DCT (j_compress_ptr cinfo, jpeg_component_info * compptr,
 METHODDEF(void)
 forward_DCT_float (j_compress_ptr cinfo, jpeg_component_info * compptr,
            JSAMPARRAY sample_data, JBLOCKROW coef_blocks,
-           JDIMENSION start_row, JDIMENSION start_col,
-           JDIMENSION num_blocks)
+           JDIMENSION start_col, JDIMENSION num_blocks)
 /* This version is used for floating-point DCT implementations. */
 {
   /* This routine is heavily used, so it's worth coding it tightly. */
@@ -146,8 +142,6 @@ forward_DCT_float (j_compress_ptr cinfo, jpeg_component_info * compptr,
   FAST_FLOAT * divisors = (FAST_FLOAT *) compptr->dct_table;
   FAST_FLOAT workspace[DCTSIZE2]; /* work area for FDCT subroutine */
   JDIMENSION bi;
-
-  sample_data += start_row;    /* fold in the vertical offset once */
 
   for (bi = 0; bi < num_blocks; bi++, start_col += compptr->DCT_h_scaled_size) {
     /* Perform the DCT */
@@ -347,13 +341,11 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
 #endif
       default:
     ERREXIT(cinfo, JERR_NOT_COMPILED);
-    break;
       }
       break;
     default:
       ERREXIT2(cinfo, JERR_BAD_DCTSIZE,
            compptr->DCT_h_scaled_size, compptr->DCT_v_scaled_size);
-      break;
     }
     qtblno = compptr->quant_tbl_no;
     /* Make sure specified quantization table is present */
@@ -444,7 +436,6 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
 #endif
     default:
       ERREXIT(cinfo, JERR_NOT_COMPILED);
-      break;
     }
   }
 }
@@ -461,17 +452,15 @@ jinit_forward_dct (j_compress_ptr cinfo)
   int ci;
   jpeg_component_info *compptr;
 
-  fdct = (my_fdct_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(my_fdct_controller));
+  fdct = (my_fdct_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_fdct_controller));
   cinfo->fdct = &fdct->pub;
   fdct->pub.start_pass = start_pass_fdctmgr;
 
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
     /* Allocate a divisor table for each component */
-    compptr->dct_table =
-      (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                  SIZEOF(divisor_table));
+    compptr->dct_table = (*cinfo->mem->alloc_small)
+      ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(divisor_table));
   }
 }

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jchuff.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jchuff.c
@@ -544,7 +544,7 @@ emit_restart_e (huff_entropy_ptr entropy, int restart_num)
  */
 
 METHODDEF(boolean)
-encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   register int temp, temp2;
@@ -627,7 +627,7 @@ encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   const int * natural_order;
@@ -738,7 +738,7 @@ encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   int Al, blkn;
@@ -781,7 +781,7 @@ encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-encode_mcu_AC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_AC_refine (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   const int * natural_order;
@@ -1013,7 +1013,7 @@ encode_one_block (working_state * state, JCOEFPTR block, int last_dc_val,
  */
 
 METHODDEF(boolean)
-encode_mcu_huff (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_huff (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   working_state state;
@@ -1194,7 +1194,7 @@ htest_one_block (j_compress_ptr cinfo, JCOEFPTR block, int last_dc_val,
  */
 
 METHODDEF(boolean)
-encode_mcu_gather (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_gather (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   int blkn, ci;

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jcmaster.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jcmaster.c
@@ -432,9 +432,7 @@ per_scan_setup (j_compress_ptr cinfo)
     cinfo->MCUs_per_row = (JDIMENSION)
       jdiv_round_up((long) cinfo->jpeg_width,
             (long) (cinfo->max_h_samp_factor * cinfo->block_size));
-    cinfo->MCU_rows_in_scan = (JDIMENSION)
-      jdiv_round_up((long) cinfo->jpeg_height,
-            (long) (cinfo->max_v_samp_factor * cinfo->block_size));
+    cinfo->MCU_rows_in_scan = cinfo->total_iMCU_rows;
 
     cinfo->blocks_in_MCU = 0;
 

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jcparam.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jcparam.c
@@ -76,7 +76,7 @@ static const unsigned int std_luminance_quant_tbl[DCTSIZE2] = {
   72,  92,  95,  98, 112, 100, 103,  99
 };
 static const unsigned int std_chrominance_quant_tbl[DCTSIZE2] = {
-  17,  18,  24,  47,  99,  99,  99,  99,
+  16,  18,  24,  47,  99,  99,  99,  99,
   18,  21,  26,  66,  99,  99,  99,  99,
   24,  26,  56,  99,  99,  99,  99,  99,
   47,  66,  99,  99,  99,  99,  99,  99,
@@ -379,11 +379,13 @@ jpeg_set_colorspace (j_compress_ptr cinfo, J_COLOR_SPACE colorspace)
   case JCS_RGB:
     cinfo->write_Adobe_marker = TRUE; /* write Adobe marker to flag RGB */
     cinfo->num_components = 3;
-    SET_COMP(0, 0x52 /* 'R' */, 1,1, 0,
+    SET_COMP(0, 0x52 /* 'R' */, 1,1,
+        cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
         cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
         cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0);
     SET_COMP(1, 0x47 /* 'G' */, 1,1, 0, 0,0);
-    SET_COMP(2, 0x42 /* 'B' */, 1,1, 0,
+    SET_COMP(2, 0x42 /* 'B' */, 1,1,
+        cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
         cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
         cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0);
     break;
@@ -417,11 +419,13 @@ jpeg_set_colorspace (j_compress_ptr cinfo, J_COLOR_SPACE colorspace)
     cinfo->JFIF_major_version = 2;   /* Set JFIF major version = 2 */
     cinfo->num_components = 3;
     /* Add offset 0x20 to the normal R/G/B component IDs */
-    SET_COMP(0, 0x72 /* 'r' */, 1,1, 0,
+    SET_COMP(0, 0x72 /* 'r' */, 1,1,
+        cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
         cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
         cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0);
     SET_COMP(1, 0x67 /* 'g' */, 1,1, 0, 0,0);
-    SET_COMP(2, 0x62 /* 'b' */, 1,1, 0,
+    SET_COMP(2, 0x62 /* 'b' */, 1,1,
+        cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
         cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
         cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0);
     break;

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jcprepct.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jcprepct.c
@@ -109,7 +109,8 @@ expand_bottom_edge (JSAMPARRAY image_data, JDIMENSION num_cols,
   register int row;
 
   for (row = input_rows; row < output_rows; row++) {
-    jcopy_sample_rows(image_data, input_rows-1, image_data, row,
+    jcopy_sample_rows(image_data + input_rows - 1,
+              image_data + row,
               1, num_cols);
   }
 }
@@ -220,8 +221,8 @@ pre_process_context (j_compress_ptr cinfo,
     for (ci = 0; ci < cinfo->num_components; ci++) {
       int row;
       for (row = 1; row <= cinfo->max_v_samp_factor; row++) {
-        jcopy_sample_rows(prep->color_buf[ci], 0,
-                  prep->color_buf[ci], -row,
+        jcopy_sample_rows(prep->color_buf[ci],
+                  prep->color_buf[ci] - row,
                   1, cinfo->image_width);
       }
     }
@@ -277,10 +278,9 @@ create_context_buffer (j_compress_ptr cinfo)
   /* Grab enough space for fake row pointers for all the components;
    * we need five row groups' worth of pointers for each component.
    */
-  fake_buffer = (JSAMPARRAY)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                (cinfo->num_components * 5 * rgroup_height) *
-                SIZEOF(JSAMPROW));
+  fake_buffer = (JSAMPARRAY) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE,
+     (cinfo->num_components * 5 * rgroup_height) * SIZEOF(JSAMPROW));
 
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
@@ -324,10 +324,9 @@ jinit_c_prep_controller (j_compress_ptr cinfo, boolean need_full_buffer)
   if (need_full_buffer)        /* safety check */
     ERREXIT(cinfo, JERR_BAD_BUFFER_MODE);
 
-  prep = (my_prep_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(my_prep_controller));
-  cinfo->prep = (struct jpeg_c_prep_controller *) prep;
+  prep = (my_prep_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_prep_controller));
+  cinfo->prep = &prep->pub;
   prep->pub.start_pass = start_pass_prep;
 
   /* Allocate the color conversion buffer.

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jcsample.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jcsample.c
@@ -200,7 +200,7 @@ fullsize_downsample (j_compress_ptr cinfo, jpeg_component_info * compptr,
              JSAMPARRAY input_data, JSAMPARRAY output_data)
 {
   /* Copy the data */
-  jcopy_sample_rows(input_data, 0, output_data, 0,
+  jcopy_sample_rows(input_data, output_data,
             cinfo->max_v_samp_factor, cinfo->image_width);
   /* Edge-expand */
   expand_right_edge(output_data, cinfo->max_v_samp_factor, cinfo->image_width,
@@ -483,10 +483,9 @@ jinit_downsampler (j_compress_ptr cinfo)
   boolean smoothok = TRUE;
   int h_in_group, v_in_group, h_out_group, v_out_group;
 
-  downsample = (my_downsample_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(my_downsampler));
-  cinfo->downsample = (struct jpeg_downsampler *) downsample;
+  downsample = (my_downsample_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_downsampler));
+  cinfo->downsample = &downsample->pub;
   downsample->pub.start_pass = start_pass_downsample;
   downsample->pub.downsample = sep_downsample;
   downsample->pub.need_context_rows = FALSE;

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jctrans.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jctrans.c
@@ -224,7 +224,7 @@ typedef struct {
   struct jpeg_c_coef_controller pub; /* public fields */
 
   JDIMENSION iMCU_row_num;    /* iMCU row # within image */
-  JDIMENSION mcu_ctr;        /* counts MCUs processed in current row */
+  JDIMENSION MCU_ctr;        /* counts MCUs processed in current row */
   int MCU_vert_offset;        /* counts MCU rows within iMCU row */
   int MCU_rows_per_iMCU_row;    /* number of such rows needed */
 
@@ -232,7 +232,7 @@ typedef struct {
   jvirt_barray_ptr * whole_image;
 
   /* Workspace for constructing dummy blocks at right/bottom edges. */
-  JBLOCKROW dummy_buffer[C_MAX_BLOCKS_IN_MCU];
+  JBLOCK dummy_buffer[C_MAX_BLOCKS_IN_MCU];
 } my_coef_controller;
 
 typedef my_coef_controller * my_coef_ptr;
@@ -257,7 +257,7 @@ start_iMCU_row (j_compress_ptr cinfo)
       coef->MCU_rows_per_iMCU_row = cinfo->cur_comp_info[0]->last_row_height;
   }
 
-  coef->mcu_ctr = 0;
+  coef->MCU_ctr = 0;
   coef->MCU_vert_offset = 0;
 }
 
@@ -315,25 +315,29 @@ compress_output (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
   /* Loop to process one whole iMCU row */
   for (yoffset = coef->MCU_vert_offset; yoffset < coef->MCU_rows_per_iMCU_row;
        yoffset++) {
-    for (MCU_col_num = coef->mcu_ctr; MCU_col_num < cinfo->MCUs_per_row;
+    for (MCU_col_num = coef->MCU_ctr; MCU_col_num <= last_MCU_col;
      MCU_col_num++) {
       /* Construct list of pointers to DCT blocks belonging to this MCU */
       blkn = 0;            /* index of current DCT block within MCU */
       for (ci = 0; ci < cinfo->comps_in_scan; ci++) {
     compptr = cinfo->cur_comp_info[ci];
-    start_col = MCU_col_num * compptr->MCU_width;
     blockcnt = (MCU_col_num < last_MCU_col) ? compptr->MCU_width
                         : compptr->last_col_width;
+    start_col = MCU_col_num * compptr->MCU_width;
     for (yindex = 0; yindex < compptr->MCU_height; yindex++) {
       if (coef->iMCU_row_num < last_iMCU_row ||
-          yindex+yoffset < compptr->last_row_height) {
+          yoffset + yindex < compptr->last_row_height) {
         /* Fill in pointers to real blocks in this row */
-        buffer_ptr = buffer[ci][yindex+yoffset] + start_col;
-        for (xindex = 0; xindex < blockcnt; xindex++)
+        buffer_ptr = buffer[ci][yoffset + yindex] + start_col;
+        xindex = blockcnt;
+        do {
           MCU_buffer[blkn++] = buffer_ptr++;
+        } while (--xindex);
+        if ((xindex = compptr->MCU_width - blockcnt) == 0)
+          continue;
       } else {
         /* At bottom of image, need a whole row of dummy blocks */
-        xindex = 0;
+        xindex = compptr->MCU_width;
       }
       /* Fill in any dummy blocks needed in this row.
        * Dummy blocks are filled in the same way as in jccoefct.c:
@@ -341,23 +345,23 @@ compress_output (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
        * block's DC value.  The init routine has already zeroed the
        * AC entries, so we need only set the DC entries correctly.
        */
-      for (; xindex < compptr->MCU_width; xindex++) {
-        MCU_buffer[blkn] = coef->dummy_buffer[blkn];
-        MCU_buffer[blkn][0][0] = MCU_buffer[blkn-1][0][0];
-        blkn++;
-      }
+      buffer_ptr = coef->dummy_buffer + blkn;
+      do {
+        buffer_ptr[0][0] = MCU_buffer[blkn-1][0][0];
+        MCU_buffer[blkn++] = buffer_ptr++;
+      } while (--xindex);
     }
       }
       /* Try to write the MCU. */
       if (! (*cinfo->entropy->encode_mcu) (cinfo, MCU_buffer)) {
     /* Suspension forced; update state counters and exit */
     coef->MCU_vert_offset = yoffset;
-    coef->mcu_ctr = MCU_col_num;
+    coef->MCU_ctr = MCU_col_num;
     return FALSE;
       }
     }
     /* Completed an MCU row, but perhaps not an iMCU row */
-    coef->mcu_ctr = 0;
+    coef->MCU_ctr = 0;
   }
   /* Completed the iMCU row, advance counters for next one */
   coef->iMCU_row_num++;
@@ -379,12 +383,9 @@ transencode_coef_controller (j_compress_ptr cinfo,
                  jvirt_barray_ptr * coef_arrays)
 {
   my_coef_ptr coef;
-  JBLOCKROW buffer;
-  int i;
 
-  coef = (my_coef_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(my_coef_controller));
+  coef = (my_coef_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_coef_controller));
   cinfo->coef = &coef->pub;
   coef->pub.start_pass = start_pass_coef;
   coef->pub.compress_data = compress_output;
@@ -393,11 +394,5 @@ transencode_coef_controller (j_compress_ptr cinfo,
   coef->whole_image = coef_arrays;
 
   /* Allocate and pre-zero space for dummy DCT blocks. */
-  buffer = (JBLOCKROW)
-    (*cinfo->mem->alloc_large) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                C_MAX_BLOCKS_IN_MCU * SIZEOF(JBLOCK));
-  FMEMZERO((void FAR *) buffer, C_MAX_BLOCKS_IN_MCU * SIZEOF(JBLOCK));
-  for (i = 0; i < C_MAX_BLOCKS_IN_MCU; i++) {
-    coef->dummy_buffer[i] = buffer + i;
-  }
+  MEMZERO(coef->dummy_buffer, SIZEOF(coef->dummy_buffer));
 }

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jdapimin.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jdapimin.c
@@ -114,7 +114,7 @@ jpeg_abort_decompress (j_decompress_ptr cinfo)
 LOCAL(void)
 default_decompress_parms (j_decompress_ptr cinfo)
 {
-  int cid0, cid1, cid2;
+  int cid0, cid1, cid2, cid3;
 
   /* Guess the input colorspace, and set output colorspace accordingly. */
   /* Note application may override our guesses. */
@@ -151,7 +151,6 @@ default_decompress_parms (j_decompress_ptr cinfo)
       default:
     WARNMS1(cinfo, JWRN_ADOBE_XFORM, cinfo->Adobe_transform);
     cinfo->jpeg_color_space = JCS_YCbCr;    /* assume it's YCbCr */
-    break;
       }
     } else {
       TRACEMS3(cinfo, 1, JTRC_UNKNOWN_IDS, cid0, cid1, cid2);
@@ -162,7 +161,15 @@ default_decompress_parms (j_decompress_ptr cinfo)
     break;
 
   case 4:
-    if (cinfo->saw_Adobe_marker) {
+    cid0 = cinfo->comp_info[0].component_id;
+    cid1 = cinfo->comp_info[1].component_id;
+    cid2 = cinfo->comp_info[2].component_id;
+    cid3 = cinfo->comp_info[3].component_id;
+    if      (cid0 == 0x01 && cid1 == 0x02 && cid2 == 0x03 && cid3 == 0x04)
+      cinfo->jpeg_color_space = JCS_YCCK;
+    else if (cid0 == 0x43 && cid1 == 0x4D && cid2 == 0x59 && cid3 == 0x4B)
+      cinfo->jpeg_color_space = JCS_CMYK;   /* ASCII 'C', 'M', 'Y', 'K' */
+    else if (cinfo->saw_Adobe_marker) {
       switch (cinfo->Adobe_transform) {
       case 0:
     cinfo->jpeg_color_space = JCS_CMYK;
@@ -173,7 +180,6 @@ default_decompress_parms (j_decompress_ptr cinfo)
       default:
     WARNMS1(cinfo, JWRN_ADOBE_XFORM, cinfo->Adobe_transform);
     cinfo->jpeg_color_space = JCS_YCCK;    /* assume it's YCCK */
-    break;
       }
     } else {
       /* No special markers, assume straight CMYK. */
@@ -185,7 +191,6 @@ default_decompress_parms (j_decompress_ptr cinfo)
   default:
     cinfo->jpeg_color_space = JCS_UNKNOWN;
     cinfo->out_color_space = JCS_UNKNOWN;
-    break;
   }
 
   /* Set defaults for other decompression parameters. */

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jdcoefct.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jdcoefct.c
@@ -2,7 +2,7 @@
  * jdcoefct.c
  *
  * Copyright (C) 1994-1997, Thomas G. Lane.
- * Modified 2002-2011 by Guido Vollbeding.
+ * Modified 2002-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -19,10 +19,12 @@
 #include "jinclude.h"
 #include "jpeglib.h"
 
+
 /* Block smoothing is only applicable for progressive JPEG, so: */
 #ifndef D_PROGRESSIVE_SUPPORTED
 #undef BLOCK_SMOOTHING_SUPPORTED
 #endif
+
 
 /* Private buffer controller object */
 
@@ -38,11 +40,8 @@ typedef struct {
   /* The output side's location is represented by cinfo->output_iMCU_row. */
 
   /* In single-pass modes, it's sufficient to buffer just one MCU.
-   * We allocate a workspace of D_MAX_BLOCKS_IN_MCU coefficient blocks,
+   * We append a workspace of D_MAX_BLOCKS_IN_MCU coefficient blocks,
    * and let the entropy decoder write into that workspace each time.
-   * (On 80x86, the workspace is FAR even though it's not really very big;
-   * this is to keep the module interfaces unchanged when a large coefficient
-   * buffer is necessary.)
    * In multi-pass modes, this array points to the current MCU's blocks
    * within the virtual arrays; it is used only by the input side.
    */
@@ -58,9 +57,13 @@ typedef struct {
   int * coef_bits_latch;
 #define SAVED_COEFS  6        /* we save coef_bits[0..5] */
 #endif
+
+  /* Workspace for single-pass modes (omitted otherwise). */
+  JBLOCK blk_buffer[D_MAX_BLOCKS_IN_MCU];
 } my_coef_controller;
 
 typedef my_coef_controller * my_coef_ptr;
+
 
 /* Forward declarations */
 METHODDEF(int) decompress_onepass
@@ -151,7 +154,8 @@ decompress_onepass (j_decompress_ptr cinfo, JSAMPIMAGE output_buf)
   JDIMENSION MCU_col_num;    /* index of current MCU within row */
   JDIMENSION last_MCU_col = cinfo->MCUs_per_row - 1;
   JDIMENSION last_iMCU_row = cinfo->total_iMCU_rows - 1;
-  int blkn, ci, xindex, yindex, yoffset, useful_width;
+  int ci, xindex, yindex, yoffset, useful_width;
+  JBLOCKROW blkp;
   JSAMPARRAY output_ptr;
   JDIMENSION start_col, output_col;
   jpeg_component_info *compptr;
@@ -162,10 +166,10 @@ decompress_onepass (j_decompress_ptr cinfo, JSAMPIMAGE output_buf)
        yoffset++) {
     for (MCU_col_num = coef->MCU_ctr; MCU_col_num <= last_MCU_col;
      MCU_col_num++) {
+      blkp = coef->blk_buffer;    /* pointer to current DCT block within MCU */
       /* Try to fetch an MCU.  Entropy decoder expects buffer to be zeroed. */
       if (cinfo->lim_Se)    /* can bypass in DC only case */
-    FMEMZERO((void FAR *) coef->MCU_buffer[0],
-         (size_t) (cinfo->blocks_in_MCU * SIZEOF(JBLOCK)));
+    MEMZERO(blkp, cinfo->blocks_in_MCU * SIZEOF(JBLOCK));
       if (! (*cinfo->entropy->decode_mcu) (cinfo, coef->MCU_buffer)) {
     /* Suspension forced; update state counters and exit */
     coef->MCU_vert_offset = yoffset;
@@ -173,37 +177,34 @@ decompress_onepass (j_decompress_ptr cinfo, JSAMPIMAGE output_buf)
     return JPEG_SUSPENDED;
       }
       /* Determine where data should go in output_buf and do the IDCT thing.
-       * We skip dummy blocks at the right and bottom edges (but blkn gets
-       * incremented past them!).  Note the inner loop relies on having
-       * allocated the MCU_buffer[] blocks sequentially.
+       * We skip dummy blocks at the right and bottom edges (but blkp gets
+       * incremented past them!).
        */
-      blkn = 0;            /* index of current DCT block within MCU */
       for (ci = 0; ci < cinfo->comps_in_scan; ci++) {
     compptr = cinfo->cur_comp_info[ci];
     /* Don't bother to IDCT an uninteresting component. */
     if (! compptr->component_needed) {
-      blkn += compptr->MCU_blocks;
+      blkp += compptr->MCU_blocks;
       continue;
     }
     inverse_DCT = cinfo->idct->inverse_DCT[compptr->component_index];
-    useful_width = (MCU_col_num < last_MCU_col) ? compptr->MCU_width
-                            : compptr->last_col_width;
     output_ptr = output_buf[compptr->component_index] +
       yoffset * compptr->DCT_v_scaled_size;
+    useful_width = (MCU_col_num < last_MCU_col) ? compptr->MCU_width
+                            : compptr->last_col_width;
     start_col = MCU_col_num * compptr->MCU_sample_width;
     for (yindex = 0; yindex < compptr->MCU_height; yindex++) {
       if (cinfo->input_iMCU_row < last_iMCU_row ||
-          yoffset+yindex < compptr->last_row_height) {
+          yoffset + yindex < compptr->last_row_height) {
         output_col = start_col;
         for (xindex = 0; xindex < useful_width; xindex++) {
-          (*inverse_DCT) (cinfo, compptr,
-                  (JCOEFPTR) coef->MCU_buffer[blkn+xindex],
+          (*inverse_DCT) (cinfo, compptr, (JCOEFPTR) (blkp + xindex),
                   output_ptr, output_col);
           output_col += compptr->DCT_h_scaled_size;
         }
+        output_ptr += compptr->DCT_v_scaled_size;
       }
-      blkn += compptr->MCU_width;
-      output_ptr += compptr->DCT_v_scaled_size;
+      blkp += compptr->MCU_width;
     }
       }
     }
@@ -212,7 +213,7 @@ decompress_onepass (j_decompress_ptr cinfo, JSAMPIMAGE output_buf)
   }
   /* Completed the iMCU row, advance counters for next one */
   cinfo->output_iMCU_row++;
-  if (++(cinfo->input_iMCU_row) < cinfo->total_iMCU_rows) {
+  if (++(cinfo->input_iMCU_row) <= last_iMCU_row) {
     start_iMCU_row(cinfo);
     return JPEG_ROW_COMPLETED;
   }
@@ -247,8 +248,9 @@ consume_data (j_decompress_ptr cinfo)
 {
   my_coef_ptr coef = (my_coef_ptr) cinfo->coef;
   JDIMENSION MCU_col_num;    /* index of current MCU within row */
-  int blkn, ci, xindex, yindex, yoffset;
+  int ci, xindex, yindex, yoffset;
   JDIMENSION start_col;
+  JBLOCKARRAY blkp;
   JBLOCKARRAY buffer[MAX_COMPS_IN_SCAN];
   JBLOCKROW buffer_ptr;
   jpeg_component_info *compptr;
@@ -272,15 +274,16 @@ consume_data (j_decompress_ptr cinfo)
     for (MCU_col_num = coef->MCU_ctr; MCU_col_num < cinfo->MCUs_per_row;
      MCU_col_num++) {
       /* Construct list of pointers to DCT blocks belonging to this MCU */
-      blkn = 0;            /* index of current DCT block within MCU */
+      blkp = coef->MCU_buffer;    /* pointer to current DCT block within MCU */
       for (ci = 0; ci < cinfo->comps_in_scan; ci++) {
     compptr = cinfo->cur_comp_info[ci];
     start_col = MCU_col_num * compptr->MCU_width;
     for (yindex = 0; yindex < compptr->MCU_height; yindex++) {
-      buffer_ptr = buffer[ci][yindex+yoffset] + start_col;
-      for (xindex = 0; xindex < compptr->MCU_width; xindex++) {
-        coef->MCU_buffer[blkn++] = buffer_ptr++;
-      }
+      buffer_ptr = buffer[ci][yoffset + yindex] + start_col;
+      xindex = compptr->MCU_width;
+      do {
+        *blkp++ = buffer_ptr++;
+      } while (--xindex);
     }
       }
       /* Try to fetch the MCU. */
@@ -370,7 +373,7 @@ decompress_data (j_decompress_ptr cinfo, JSAMPIMAGE output_buf)
     }
   }
 
-  if (++(cinfo->output_iMCU_row) < cinfo->total_iMCU_rows)
+  if (++(cinfo->output_iMCU_row) <= last_iMCU_row)
     return JPEG_ROW_COMPLETED;
   return JPEG_SCAN_COMPLETED;
 }
@@ -419,10 +422,9 @@ smoothing_ok (j_decompress_ptr cinfo)
 
   /* Allocate latch area if not already done */
   if (coef->coef_bits_latch == NULL)
-    coef->coef_bits_latch = (int *)
-      (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                  cinfo->num_components *
-                  (SAVED_COEFS * SIZEOF(int)));
+    coef->coef_bits_latch = (int *) (*cinfo->mem->alloc_small)
+      ((j_common_ptr) cinfo, JPOOL_IMAGE,
+       cinfo->num_components * (SAVED_COEFS * SIZEOF(int)));
   coef_bits_latch = coef->coef_bits_latch;
 
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
@@ -662,7 +664,7 @@ decompress_smooth_data (j_decompress_ptr cinfo, JSAMPIMAGE output_buf)
     }
   }
 
-  if (++(cinfo->output_iMCU_row) < cinfo->total_iMCU_rows)
+  if (++(cinfo->output_iMCU_row) <= last_iMCU_row)
     return JPEG_ROW_COMPLETED;
   return JPEG_SCAN_COMPLETED;
 }
@@ -679,17 +681,6 @@ jinit_d_coef_controller (j_decompress_ptr cinfo, boolean need_full_buffer)
 {
   my_coef_ptr coef;
 
-  coef = (my_coef_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(my_coef_controller));
-  cinfo->coef = (struct jpeg_d_coef_controller *) coef;
-  coef->pub.start_input_pass = start_input_pass;
-  coef->pub.start_output_pass = start_output_pass;
-#ifdef BLOCK_SMOOTHING_SUPPORTED
-  coef->coef_bits_latch = NULL;
-#endif
-
-  /* Create the coefficient buffer. */
   if (need_full_buffer) {
 #ifdef D_MULTISCAN_FILES_SUPPORTED
     /* Allocate a full-image virtual array for each component, */
@@ -698,6 +689,9 @@ jinit_d_coef_controller (j_decompress_ptr cinfo, boolean need_full_buffer)
     int ci, access_rows;
     jpeg_component_info *compptr;
 
+    coef = (my_coef_ptr) (*cinfo->mem->alloc_small)
+      ((j_common_ptr) cinfo, JPOOL_IMAGE,
+       SIZEOF(my_coef_controller) - SIZEOF(coef->blk_buffer));
     for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
      ci++, compptr++) {
       access_rows = compptr->v_samp_factor;
@@ -722,20 +716,29 @@ jinit_d_coef_controller (j_decompress_ptr cinfo, boolean need_full_buffer)
 #endif
   } else {
     /* We only need a single-MCU buffer. */
-    JBLOCKROW buffer;
-    int i;
+    JBLOCKARRAY blkp;
+    JBLOCKROW buffer_ptr;
+    int bi;
 
-    buffer = (JBLOCKROW)
-      (*cinfo->mem->alloc_large) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                  D_MAX_BLOCKS_IN_MCU * SIZEOF(JBLOCK));
-    for (i = 0; i < D_MAX_BLOCKS_IN_MCU; i++) {
-      coef->MCU_buffer[i] = buffer + i;
-    }
+    coef = (my_coef_ptr) (*cinfo->mem->alloc_small)
+      ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_coef_controller));
+    buffer_ptr = coef->blk_buffer;
     if (cinfo->lim_Se == 0)    /* DC only case: want to bypass later */
-      FMEMZERO((void FAR *) buffer,
-           (size_t) (D_MAX_BLOCKS_IN_MCU * SIZEOF(JBLOCK)));
+      MEMZERO(buffer_ptr, SIZEOF(coef->blk_buffer));
+    blkp = coef->MCU_buffer;
+    bi = D_MAX_BLOCKS_IN_MCU;
+    do {
+      *blkp++ = buffer_ptr++;
+    } while (--bi);
     coef->pub.consume_data = dummy_consume_data;
     coef->pub.decompress_data = decompress_onepass;
     coef->pub.coef_arrays = NULL; /* flag for no virtual arrays */
   }
+
+  coef->pub.start_input_pass = start_input_pass;
+  coef->pub.start_output_pass = start_output_pass;
+#ifdef BLOCK_SMOOTHING_SUPPORTED
+  coef->coef_bits_latch = NULL;
+#endif
+  cinfo->coef = &coef->pub;
 }

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jdhuff.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jdhuff.c
@@ -708,7 +708,7 @@ process_restart (j_decompress_ptr cinfo)
  */
 
 METHODDEF(boolean)
-decode_mcu_DC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_DC_first (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   int Al = cinfo->Al;
@@ -780,7 +780,7 @@ decode_mcu_DC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu_AC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_AC_first (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   register int s, k, r;
@@ -868,7 +868,7 @@ decode_mcu_AC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu_DC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_DC_refine (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   JCOEF p1;
@@ -917,7 +917,7 @@ decode_mcu_DC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu_AC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_AC_refine (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   register int s, k, r;
@@ -1076,7 +1076,7 @@ undoit:
  */
 
 METHODDEF(boolean)
-decode_mcu_sub (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_sub (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   const int * natural_order;
@@ -1205,7 +1205,7 @@ decode_mcu_sub (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   int blkn;

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jdinput.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jdinput.c
@@ -330,7 +330,6 @@ initial_setup (j_decompress_ptr cinfo)
     default:
       ERREXIT4(cinfo, JERR_BAD_PROGRESSION,
            cinfo->Ss, cinfo->Se, cinfo->Ah, cinfo->Al);
-      break;
     }
 
   /* We initialize DCT_scaled_size and min_DCT_scaled_size to block_size.
@@ -429,9 +428,7 @@ per_scan_setup (j_decompress_ptr cinfo)
     cinfo->MCUs_per_row = (JDIMENSION)
       jdiv_round_up((long) cinfo->image_width,
             (long) (cinfo->max_h_samp_factor * cinfo->block_size));
-    cinfo->MCU_rows_in_scan = (JDIMENSION)
-      jdiv_round_up((long) cinfo->image_height,
-            (long) (cinfo->max_v_samp_factor * cinfo->block_size));
+    cinfo->MCU_rows_in_scan = cinfo->total_iMCU_rows;
 
     cinfo->blocks_in_MCU = 0;
 
@@ -501,9 +498,8 @@ latch_quant_tables (j_decompress_ptr cinfo)
     cinfo->quant_tbl_ptrs[qtblno] == NULL)
       ERREXIT1(cinfo, JERR_NO_QUANT_TABLE, qtblno);
     /* OK, save away the quantization table */
-    qtbl = (JQUANT_TBL *)
-      (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                  SIZEOF(JQUANT_TBL));
+    qtbl = (JQUANT_TBL *) (*cinfo->mem->alloc_small)
+      ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(JQUANT_TBL));
     MEMCOPY(qtbl, cinfo->quant_tbl_ptrs[qtblno], SIZEOF(JQUANT_TBL));
     compptr->quant_table = qtbl;
   }
@@ -644,9 +640,8 @@ jinit_input_controller (j_decompress_ptr cinfo)
   my_inputctl_ptr inputctl;
 
   /* Create subobject in permanent pool */
-  inputctl = (my_inputctl_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_PERMANENT,
-                SIZEOF(my_input_controller));
+  inputctl = (my_inputctl_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_PERMANENT, SIZEOF(my_input_controller));
   cinfo->inputctl = &inputctl->pub;
   /* Initialize method pointers */
   inputctl->pub.consume_input = consume_markers;

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jdmainct.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jdmainct.c
@@ -170,21 +170,22 @@ alloc_funny_pointers (j_decompress_ptr cinfo)
   /* Get top-level space for component array pointers.
    * We alloc both arrays with one call to save a few cycles.
    */
-  mainp->xbuffer[0] = (JSAMPIMAGE)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
+  mainp->xbuffer[0] = (JSAMPIMAGE) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE,
                 cinfo->num_components * 2 * SIZEOF(JSAMPARRAY));
   mainp->xbuffer[1] = mainp->xbuffer[0] + cinfo->num_components;
 
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
+    if (! compptr->component_needed)
+      continue;            /* skip uninteresting component */
     rgroup = (compptr->v_samp_factor * compptr->DCT_v_scaled_size) /
       cinfo->min_DCT_v_scaled_size; /* height of a row group of component */
     /* Get space for pointer lists --- M+4 row groups in each list.
      * We alloc both pointer lists with one call to save a few cycles.
      */
-    xbuf = (JSAMPARRAY)
-      (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                  2 * (rgroup * (M + 4)) * SIZEOF(JSAMPROW));
+    xbuf = (JSAMPARRAY) (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo,
+      JPOOL_IMAGE, 2 * (rgroup * (M + 4)) * SIZEOF(JSAMPROW));
     xbuf += rgroup;        /* want one row group at negative offsets */
     mainp->xbuffer[0][ci] = xbuf;
     xbuf += rgroup * (M + 4);
@@ -210,6 +211,8 @@ make_funny_pointers (j_decompress_ptr cinfo)
 
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
+    if (! compptr->component_needed)
+      continue;            /* skip uninteresting component */
     rgroup = (compptr->v_samp_factor * compptr->DCT_v_scaled_size) /
       cinfo->min_DCT_v_scaled_size; /* height of a row group of component */
     xbuf0 = mainp->xbuffer[0][ci];
@@ -250,6 +253,8 @@ set_wraparound_pointers (j_decompress_ptr cinfo)
 
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
+    if (! compptr->component_needed)
+      continue;            /* skip uninteresting component */
     rgroup = (compptr->v_samp_factor * compptr->DCT_v_scaled_size) /
       cinfo->min_DCT_v_scaled_size; /* height of a row group of component */
     xbuf0 = mainp->xbuffer[0][ci];
@@ -278,6 +283,8 @@ set_bottom_pointers (j_decompress_ptr cinfo)
 
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
+    if (! compptr->component_needed)
+      continue;            /* skip uninteresting component */
     /* Count sample rows in one iMCU row and in one row group */
     iMCUheight = compptr->v_samp_factor * compptr->DCT_v_scaled_size;
     rgroup = iMCUheight / cinfo->min_DCT_v_scaled_size;
@@ -333,7 +340,6 @@ start_pass_main (j_decompress_ptr cinfo, J_BUF_MODE pass_mode)
 #endif
   default:
     ERREXIT(cinfo, JERR_BAD_BUFFER_MODE);
-    break;
   }
 }
 
@@ -344,9 +350,8 @@ start_pass_main (j_decompress_ptr cinfo, J_BUF_MODE pass_mode)
  */
 
 METHODDEF(void)
-process_data_simple_main (j_decompress_ptr cinfo,
-              JSAMPARRAY output_buf, JDIMENSION *out_row_ctr,
-              JDIMENSION out_rows_avail)
+process_data_simple_main (j_decompress_ptr cinfo, JSAMPARRAY output_buf,
+              JDIMENSION *out_row_ctr, JDIMENSION out_rows_avail)
 {
   my_main_ptr mainp = (my_main_ptr) cinfo->main;
 
@@ -375,9 +380,8 @@ process_data_simple_main (j_decompress_ptr cinfo,
  */
 
 METHODDEF(void)
-process_data_context_main (j_decompress_ptr cinfo,
-               JSAMPARRAY output_buf, JDIMENSION *out_row_ctr,
-               JDIMENSION out_rows_avail)
+process_data_context_main (j_decompress_ptr cinfo, JSAMPARRAY output_buf,
+               JDIMENSION *out_row_ctr, JDIMENSION out_rows_avail)
 {
   my_main_ptr mainp = (my_main_ptr) cinfo->main;
 
@@ -449,9 +453,8 @@ process_data_context_main (j_decompress_ptr cinfo,
 #ifdef QUANT_2PASS_SUPPORTED
 
 METHODDEF(void)
-process_data_crank_post (j_decompress_ptr cinfo,
-             JSAMPARRAY output_buf, JDIMENSION *out_row_ctr,
-             JDIMENSION out_rows_avail)
+process_data_crank_post (j_decompress_ptr cinfo, JSAMPARRAY output_buf,
+             JDIMENSION *out_row_ctr, JDIMENSION out_rows_avail)
 {
   (*cinfo->post->post_process_data) (cinfo, (JSAMPIMAGE) NULL,
                      (JDIMENSION *) NULL, (JDIMENSION) 0,
@@ -472,9 +475,8 @@ jinit_d_main_controller (j_decompress_ptr cinfo, boolean need_full_buffer)
   int ci, rgroup, ngroups;
   jpeg_component_info *compptr;
 
-  mainp = (my_main_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(my_main_controller));
+  mainp = (my_main_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_main_controller));
   cinfo->main = &mainp->pub;
   mainp->pub.start_pass = start_pass_main;
 
@@ -497,6 +499,8 @@ jinit_d_main_controller (j_decompress_ptr cinfo, boolean need_full_buffer)
 
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
+    if (! compptr->component_needed)
+      continue;            /* skip uninteresting component */
     rgroup = (compptr->v_samp_factor * compptr->DCT_v_scaled_size) /
       cinfo->min_DCT_v_scaled_size; /* height of a row group of component */
     mainp->buffer[ci] = (*cinfo->mem->alloc_sarray)

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jdmaster.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jdmaster.c
@@ -103,10 +103,8 @@ jpeg_calc_output_dimensions (j_decompress_ptr cinfo)
  * This function is used for full decompression.
  */
 {
-#ifdef IDCT_SCALING_SUPPORTED
-  int ci, ssize;
+  int ci, i;
   jpeg_component_info *compptr;
-#endif
 
   /* Prevent application from calling me at wrong times */
   if (cinfo->global_state != DSTATE_READY)
@@ -124,7 +122,7 @@ jpeg_calc_output_dimensions (j_decompress_ptr cinfo)
    */
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
-    ssize = 1;
+    int ssize = 1;
     if (! cinfo->raw_data_out)
       while (cinfo->min_DCT_h_scaled_size * ssize <=
          (cinfo->do_fancy_upsampling ? DCTSIZE : DCTSIZE / 2) &&
@@ -173,20 +171,15 @@ jpeg_calc_output_dimensions (j_decompress_ptr cinfo)
     break;
   case JCS_RGB:
   case JCS_BG_RGB:
-#if RGB_PIXELSIZE != 3
     cinfo->out_color_components = RGB_PIXELSIZE;
     break;
-#endif /* else share code with YCbCr */
-  case JCS_YCbCr:
-  case JCS_BG_YCC:
-    cinfo->out_color_components = 3;
-    break;
-  case JCS_CMYK:
-  case JCS_YCCK:
-    cinfo->out_color_components = 4;
-    break;
   default:            /* else must be same colorspace as in file */
-    cinfo->out_color_components = cinfo->num_components;
+    i = 0;
+    for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
+     ci++, compptr++)
+      if (compptr->component_needed)
+    i++;    /* count output color components */
+    cinfo->out_color_components = i;
   }
   cinfo->output_components = (cinfo->quantize_colors ? 1 :
                   cinfo->out_color_components);

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jdmerge.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jdmerge.c
@@ -190,7 +190,7 @@ merged_2v_upsample (j_decompress_ptr cinfo,
 
   if (upsample->spare_full) {
     /* If we have a spare row saved from a previous cycle, just return it. */
-    jcopy_sample_rows(& upsample->spare_row, 0, output_buf + *out_row_ctr, 0,
+    jcopy_sample_rows(& upsample->spare_row, output_buf + *out_row_ctr,
               1, upsample->out_row_width);
     num_rows = 1;
     upsample->spare_full = FALSE;

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jdsample.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jdsample.c
@@ -27,7 +27,7 @@
 /* Pointer to routine to upsample a single component */
 typedef JMETHOD(void, upsample1_ptr,
         (j_decompress_ptr cinfo, jpeg_component_info * compptr,
-         JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr));
+         JSAMPARRAY input_data, JSAMPIMAGE output_data_ptr));
 
 /* Private subobject */
 
@@ -102,6 +102,8 @@ sep_upsample (j_decompress_ptr cinfo,
   if (upsample->next_row_out >= cinfo->max_v_samp_factor) {
     for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
      ci++, compptr++) {
+      if (! compptr->component_needed)
+    continue;
       /* Invoke per-component upsample method.  Notice we pass a POINTER
        * to color_buf[ci], so that fullsize_upsample can change it.
        */
@@ -156,10 +158,9 @@ sep_upsample (j_decompress_ptr cinfo,
 
 METHODDEF(void)
 fullsize_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
-           JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr)
+           JSAMPARRAY input_data, JSAMPIMAGE output_data_ptr)
 {
   *output_data_ptr = input_data;
-}
 
 
 /*
@@ -167,11 +168,6 @@ fullsize_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
  * These components will not be referenced by color conversion.
  */
 
-METHODDEF(void)
-noop_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
-           JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr)
-{
-  *output_data_ptr = NULL;    /* safety check */
 }
 
 
@@ -188,25 +184,25 @@ noop_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
 
 METHODDEF(void)
 int_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
-          JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr)
+          JSAMPARRAY input_data, JSAMPIMAGE output_data_ptr)
 {
   my_upsample_ptr upsample = (my_upsample_ptr) cinfo->upsample;
-  JSAMPARRAY output_data = *output_data_ptr;
+  JSAMPARRAY output_data, output_end;
   register JSAMPROW inptr, outptr;
   register JSAMPLE invalue;
   register int h;
   JSAMPROW outend;
   int h_expand, v_expand;
-  int inrow, outrow;
 
   h_expand = upsample->h_expand[compptr->component_index];
   v_expand = upsample->v_expand[compptr->component_index];
 
-  inrow = outrow = 0;
-  while (outrow < cinfo->max_v_samp_factor) {
+  output_data = *output_data_ptr;
+  output_end = output_data + cinfo->max_v_samp_factor;
+  for (; output_data < output_end; output_data += v_expand) {
     /* Generate one output row with proper horizontal expansion */
-    inptr = input_data[inrow];
-    outptr = output_data[outrow];
+    inptr = *input_data++;
+    outptr = *output_data;
     outend = outptr + cinfo->output_width;
     while (outptr < outend) {
       invalue = *inptr++;    /* don't need GETJSAMPLE() here */
@@ -216,11 +212,9 @@ int_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
     }
     /* Generate any additional output rows by duplicating the first one */
     if (v_expand > 1) {
-      jcopy_sample_rows(output_data, outrow, output_data, outrow+1,
+      jcopy_sample_rows(output_data, output_data + 1,
             v_expand-1, cinfo->output_width);
     }
-    inrow++;
-    outrow += v_expand;
   }
 }
 
@@ -232,7 +226,7 @@ int_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
 
 METHODDEF(void)
 h2v1_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
-           JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr)
+           JSAMPARRAY input_data, JSAMPIMAGE output_data_ptr)
 {
   JSAMPARRAY output_data = *output_data_ptr;
   register JSAMPROW inptr, outptr;
@@ -260,28 +254,26 @@ h2v1_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
 
 METHODDEF(void)
 h2v2_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
-           JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr)
+           JSAMPARRAY input_data, JSAMPIMAGE output_data_ptr)
 {
-  JSAMPARRAY output_data = *output_data_ptr;
+  JSAMPARRAY output_data, output_end;
   register JSAMPROW inptr, outptr;
   register JSAMPLE invalue;
   JSAMPROW outend;
-  int inrow, outrow;
 
-  inrow = outrow = 0;
-  while (outrow < cinfo->max_v_samp_factor) {
-    inptr = input_data[inrow];
-    outptr = output_data[outrow];
+  output_data = *output_data_ptr;
+  output_end = output_data + cinfo->max_v_samp_factor;
+  for (; output_data < output_end; output_data += 2) {
+    inptr = *input_data++;
+    outptr = *output_data;
     outend = outptr + cinfo->output_width;
     while (outptr < outend) {
       invalue = *inptr++;    /* don't need GETJSAMPLE() here */
       *outptr++ = invalue;
       *outptr++ = invalue;
     }
-    jcopy_sample_rows(output_data, outrow, output_data, outrow+1,
+    jcopy_sample_rows(output_data, output_data + 1,
               1, cinfo->output_width);
-    inrow++;
-    outrow += 2;
   }
 }
 
@@ -298,9 +290,8 @@ jinit_upsampler (j_decompress_ptr cinfo)
   jpeg_component_info * compptr;
   int h_in_group, v_in_group, h_out_group, v_out_group;
 
-  upsample = (my_upsample_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(my_upsampler));
+  upsample = (my_upsample_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_upsampler));
   cinfo->upsample = &upsample->pub;
   upsample->pub.start_pass = start_pass_upsample;
   upsample->pub.upsample = sep_upsample;
@@ -314,6 +305,8 @@ jinit_upsampler (j_decompress_ptr cinfo)
    */
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
+    if (! compptr->component_needed)
+      continue;
     /* Compute size of an "input group" after IDCT scaling.  This many samples
      * are to be converted to max_h_samp_factor * max_v_samp_factor pixels.
      */
@@ -324,11 +317,7 @@ jinit_upsampler (j_decompress_ptr cinfo)
     h_out_group = cinfo->max_h_samp_factor;
     v_out_group = cinfo->max_v_samp_factor;
     upsample->rowgroup_height[ci] = v_in_group; /* save for use later */
-    if (! compptr->component_needed) {
       /* Don't bother to upsample an uninteresting component. */
-      upsample->methods[ci] = noop_upsample;
-      continue;        /* don't need to allocate buffer */
-    }
     if (h_in_group == h_out_group && v_in_group == v_out_group) {
       /* Fullsize components can be processed without any work. */
       upsample->methods[ci] = fullsize_upsample;

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jpegint.h
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jpegint.h
@@ -103,8 +103,7 @@ struct jpeg_downsampler {
 typedef JMETHOD(void, forward_DCT_ptr,
         (j_compress_ptr cinfo, jpeg_component_info * compptr,
          JSAMPARRAY sample_data, JBLOCKROW coef_blocks,
-         JDIMENSION start_row, JDIMENSION start_col,
-         JDIMENSION num_blocks));
+         JDIMENSION start_col, JDIMENSION num_blocks));
 
 struct jpeg_forward_dct {
   JMETHOD(void, start_pass, (j_compress_ptr cinfo));
@@ -115,7 +114,7 @@ struct jpeg_forward_dct {
 /* Entropy encoding */
 struct jpeg_entropy_encoder {
   JMETHOD(void, start_pass, (j_compress_ptr cinfo, boolean gather_statistics));
-  JMETHOD(boolean, encode_mcu, (j_compress_ptr cinfo, JBLOCKROW *MCU_data));
+  JMETHOD(boolean, encode_mcu, (j_compress_ptr cinfo, JBLOCKARRAY MCU_data));
   JMETHOD(void, finish_pass, (j_compress_ptr cinfo));
 };
 
@@ -211,7 +210,7 @@ struct jpeg_marker_reader {
 /* Entropy decoding */
 struct jpeg_entropy_decoder {
   JMETHOD(void, start_pass, (j_decompress_ptr cinfo));
-  JMETHOD(boolean, decode_mcu, (j_decompress_ptr cinfo, JBLOCKROW *MCU_data));
+  JMETHOD(boolean, decode_mcu, (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data));
   JMETHOD(void, finish_pass, (j_decompress_ptr cinfo));
 };
 
@@ -416,8 +415,8 @@ EXTERN(void) jinit_memory_mgr JPP((j_common_ptr cinfo));
 /* Utility routines in jutils.c */
 EXTERN(long) jdiv_round_up JPP((long a, long b));
 EXTERN(long) jround_up JPP((long a, long b));
-EXTERN(void) jcopy_sample_rows JPP((JSAMPARRAY input_array, int source_row,
-                    JSAMPARRAY output_array, int dest_row,
+EXTERN(void) jcopy_sample_rows JPP((JSAMPARRAY input_array,
+                    JSAMPARRAY output_array,
                     int num_rows, JDIMENSION num_cols));
 EXTERN(void) jcopy_block_row JPP((JBLOCKROW input_row, JBLOCKROW output_row,
                   JDIMENSION num_blocks));

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jpeglib.h
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jpeglib.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #define JPEG_LIB_VERSION        90    /* Compatibility version 9.0 */
 #define JPEG_LIB_VERSION_MAJOR  9
-#define JPEG_LIB_VERSION_MINOR  4
+#define JPEG_LIB_VERSION_MINOR  5
 
 
 /* Various constants determining the sizes of things.

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jquant1.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jquant1.c
@@ -293,8 +293,7 @@ create_colormap (j_decompress_ptr cinfo)
   /* The colors are ordered in the map in standard row-major order, */
   /* i.e. rightmost (highest-indexed) color changes most rapidly. */
 
-  colormap = (*cinfo->mem->alloc_sarray)
-    ((j_common_ptr) cinfo, JPOOL_IMAGE,
+  colormap = (*cinfo->mem->alloc_sarray) ((j_common_ptr) cinfo, JPOOL_IMAGE,
      (JDIMENSION) total_colors, (JDIMENSION) cinfo->out_color_components);
 
   /* blksize is number of adjacent repeated entries for a component */
@@ -400,9 +399,8 @@ make_odither_array (j_decompress_ptr cinfo, int ncolors)
   int j,k;
   INT32 num,den;
 
-  odither = (ODITHER_MATRIX_PTR)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(ODITHER_MATRIX));
+  odither = (ODITHER_MATRIX_PTR) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(ODITHER_MATRIX));
   /* The inter-value distance for this color is MAXJSAMPLE/(ncolors-1).
    * Hence the dither value for the matrix cell with fill order f
    * (f=0..N-1) should be (N-1-2*f)/(2*N) * MAXJSAMPLE/(ncolors-1).
@@ -531,8 +529,7 @@ quantize_ord_dither (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 
   for (row = 0; row < num_rows; row++) {
     /* Initialize output values to 0 so can process components separately */
-    FMEMZERO((void FAR *) output_buf[row],
-         (size_t) (width * SIZEOF(JSAMPLE)));
+    FMEMZERO((void FAR *) output_buf[row], (size_t) width * SIZEOF(JSAMPLE));
     row_index = cquantize->row_index;
     for (ci = 0; ci < nc; ci++) {
       input_ptr = input_buf[row] + ci;
@@ -636,8 +633,7 @@ quantize_fs_dither (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 
   for (row = 0; row < num_rows; row++) {
     /* Initialize output values to 0 so can process components separately */
-    FMEMZERO((void FAR *) output_buf[row],
-         (size_t) (width * SIZEOF(JSAMPLE)));
+    FMEMZERO((void FAR *) output_buf[row], (size_t) width * SIZEOF(JSAMPLE));
     for (ci = 0; ci < nc; ci++) {
       input_ptr = input_buf[row] + ci;
       output_ptr = output_buf[row];
@@ -726,10 +722,10 @@ alloc_fs_workspace (j_decompress_ptr cinfo)
   size_t arraysize;
   int i;
 
-  arraysize = (size_t) ((cinfo->output_width + 2) * SIZEOF(FSERROR));
+  arraysize = ((size_t) cinfo->output_width + (size_t) 2) * SIZEOF(FSERROR);
   for (i = 0; i < cinfo->out_color_components; i++) {
-    cquantize->fserrors[i] = (FSERRPTR)
-      (*cinfo->mem->alloc_large)((j_common_ptr) cinfo, JPOOL_IMAGE, arraysize);
+    cquantize->fserrors[i] = (FSERRPTR) (*cinfo->mem->alloc_large)
+      ((j_common_ptr) cinfo, JPOOL_IMAGE, arraysize);
   }
 }
 
@@ -780,13 +776,12 @@ start_pass_1_quant (j_decompress_ptr cinfo, boolean is_pre_scan)
     if (cquantize->fserrors[0] == NULL)
       alloc_fs_workspace(cinfo);
     /* Initialize the propagated errors to zero. */
-    arraysize = (size_t) ((cinfo->output_width + 2) * SIZEOF(FSERROR));
+    arraysize = ((size_t) cinfo->output_width + (size_t) 2) * SIZEOF(FSERROR);
     for (i = 0; i < cinfo->out_color_components; i++)
       FMEMZERO((void FAR *) cquantize->fserrors[i], arraysize);
     break;
   default:
     ERREXIT(cinfo, JERR_NOT_COMPILED);
-    break;
   }
 }
 
@@ -823,10 +818,9 @@ jinit_1pass_quantizer (j_decompress_ptr cinfo)
 {
   my_cquantize_ptr cquantize;
 
-  cquantize = (my_cquantize_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(my_cquantizer));
-  cinfo->cquantize = (struct jpeg_color_quantizer *) cquantize;
+  cquantize = (my_cquantize_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_cquantizer));
+  cinfo->cquantize = &cquantize->pub;
   cquantize->pub.start_pass = start_pass_1_quant;
   cquantize->pub.finish_pass = finish_pass_1_quant;
   cquantize->pub.new_color_map = new_color_map_1_quant;

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jquant2.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jquant2.c
@@ -1197,8 +1197,8 @@ start_pass_2_quant (j_decompress_ptr cinfo, boolean is_pre_scan)
       ERREXIT1(cinfo, JERR_QUANT_MANY_COLORS, MAXNUMCOLORS);
 
     if (cinfo->dither_mode == JDITHER_FS) {
-      size_t arraysize = (size_t) ((cinfo->output_width + 2) *
-                   (3 * SIZEOF(FSERROR)));
+      size_t arraysize = ((size_t) cinfo->output_width + (size_t) 2)
+    * (3 * SIZEOF(FSERROR));
       /* Allocate Floyd-Steinberg workspace if we didn't already. */
       if (cquantize->fserrors == NULL)
     cquantize->fserrors = (FSERRPTR) (*cinfo->mem->alloc_large)
@@ -1247,10 +1247,9 @@ jinit_2pass_quantizer (j_decompress_ptr cinfo)
   my_cquantize_ptr cquantize;
   int i;
 
-  cquantize = (my_cquantize_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-                SIZEOF(my_cquantizer));
-  cinfo->cquantize = (struct jpeg_color_quantizer *) cquantize;
+  cquantize = (my_cquantize_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_cquantizer));
+  cinfo->cquantize = &cquantize->pub;
   cquantize->pub.start_pass = start_pass_2_quant;
   cquantize->pub.new_color_map = new_color_map_2_quant;
   cquantize->fserrors = NULL;    /* flag optional arrays not allocated */
@@ -1284,7 +1283,8 @@ jinit_2pass_quantizer (j_decompress_ptr cinfo)
     if (desired > MAXNUMCOLORS)
       ERREXIT1(cinfo, JERR_QUANT_MANY_COLORS, MAXNUMCOLORS);
     cquantize->sv_colormap = (*cinfo->mem->alloc_sarray)
-      ((j_common_ptr) cinfo,JPOOL_IMAGE, (JDIMENSION) desired, (JDIMENSION) 3);
+      ((j_common_ptr) cinfo, JPOOL_IMAGE,
+       (JDIMENSION) desired, (JDIMENSION) 3);
     cquantize->desired = desired;
   } else
     cquantize->sv_colormap = NULL;
@@ -1302,7 +1302,7 @@ jinit_2pass_quantizer (j_decompress_ptr cinfo)
   if (cinfo->dither_mode == JDITHER_FS) {
     cquantize->fserrors = (FSERRPTR) (*cinfo->mem->alloc_large)
       ((j_common_ptr) cinfo, JPOOL_IMAGE,
-       (size_t) ((cinfo->output_width + 2) * (3 * SIZEOF(FSERROR))));
+       ((size_t) cinfo->output_width + (size_t) 2) * (3 * SIZEOF(FSERROR)));
     /* Might as well create the error-limiting table too. */
     init_error_limit(cinfo);
   }

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jutils.c
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jutils.c
@@ -174,8 +174,8 @@ jzero_far (void FAR * target, size_t bytestozero)
 
 
 GLOBAL(void)
-jcopy_sample_rows (JSAMPARRAY input_array, int source_row,
-           JSAMPARRAY output_array, int dest_row,
+jcopy_sample_rows (JSAMPARRAY input_array,
+           JSAMPARRAY output_array,
            int num_rows, JDIMENSION num_cols)
 /* Copy some rows of samples from one place to another.
  * num_rows rows are copied from input_array[source_row++]
@@ -191,8 +191,6 @@ jcopy_sample_rows (JSAMPARRAY input_array, int source_row,
 #endif
   register int row;
 
-  input_array += source_row;
-  output_array += dest_row;
 
   for (row = num_rows; row > 0; row--) {
     inptr = *input_array++;

--- a/modules/javafx.graphics/src/main/native-iio/libjpeg/jversion.h
+++ b/modules/javafx.graphics/src/main/native-iio/libjpeg/jversion.h
@@ -9,6 +9,6 @@
  */
 
 
-#define JVERSION    "9d  12-Jan-2020"
+#define JVERSION    "9e  16-Jan-2022"
 
-#define JCOPYRIGHT    "Copyright (C) 2020, Thomas G. Lane, Guido Vollbeding"
+#define JCOPYRIGHT    "Copyright (C) 2022, Thomas G. Lane, Guido Vollbeding"


### PR DESCRIPTION
Clean backport, Verified on Mac and Windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289542](https://bugs.openjdk.org/browse/JDK-8289542): Update JPEG Image Decoding Software to 9e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jfx17u pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/97.diff">https://git.openjdk.org/jfx17u/pull/97.diff</a>

</details>
