### PR TITLE
8293375: add_definitions USE_SYSTEM_MALLOC when USE_SYSTEM_MALLOC is ON

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/PlatformJava.cmake
+++ b/modules/javafx.web/src/main/native/Source/WebCore/PlatformJava.cmake
@@ -78,6 +78,10 @@ list(APPEND WebCore_LIBRARIES
 
 add_definitions(-DSTATICALLY_LINKED_WITH_JavaScriptCore)
 add_definitions(-DSTATICALLY_LINKED_WITH_WTF)
+if (USE_SYSTEM_MALLOC)
+    message(STATUS "Using system malloc")
+    add_definitions(-DUSE_SYSTEM_MALLOC)
+endif ()
 
 list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/java/JavaDOMUtils.h


### PR DESCRIPTION
Clean backport. Verified on (after #102):
- Linux/LoongArch64 (`USE_SYSTEM_MALLOC` is `on`, the platform triggering this problem)
- Linux/x64 (`USE_SYSTEM_MALLOC` is `off`)
- Linux/aarch64 (`USE_SYSTEM_MALLOC` is `off`)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293375](https://bugs.openjdk.org/browse/JDK-8293375): add_definitions USE_SYSTEM_MALLOC when USE_SYSTEM_MALLOC is ON


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/103/head:pull/103` \
`$ git checkout pull/103`

Update a local copy of the PR: \
`$ git checkout pull/103` \
`$ git pull https://git.openjdk.org/jfx17u pull/103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 103`

View PR using the GUI difftool: \
`$ git pr show -t 103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/103.diff">https://git.openjdk.org/jfx17u/pull/103.diff</a>

</details>
