### PR TITLE
8277853: With Touch enabled devices scrollbar disappears and the table is scrolled to the beginning

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -2365,7 +2365,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         // Bring the clipView.clipX back to 0 if control is vertical or
         // the hbar isn't visible (fix for RT-11666)
         if (isVertical()) {
-            if (hbar.isVisible()) {
+            if (needBreadthBar) {
                 clipView.setClipX(hbar.getValue());
             } else {
                 // all cells are now less than the width of the flow,

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -798,6 +798,41 @@ public class TableViewTest {
     /*********************************************************************
      * Tests for specific bugs                                           *
      ********************************************************************/
+
+    /**
+     * JDK-8277853
+     */
+    @Test public void testInvisibleScrollbarDoesNotScrollTableToBeginning() {
+        TableView<Person> table = new TableView<>(personTestData);
+        StageLoader sl = new StageLoader(table);
+
+        TableColumn firstNameCol = new TableColumn("First Name");
+        firstNameCol.setCellValueFactory(new PropertyValueFactory<Person, String>("firstName"));
+
+        TableColumn lastNameCol = new TableColumn("Last Name");
+        lastNameCol.setCellValueFactory(new PropertyValueFactory<Person, String>("lastName"));
+
+        TableColumn emailCol = new TableColumn("Email");
+        emailCol.setCellValueFactory(new PropertyValueFactory<Person, String>("email"));
+
+        table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
+        table.setItems(personTestData);
+
+        Toolkit.getToolkit().firePulse();
+
+        ScrollBar horizontalBar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
+        assertNotNull(horizontalBar);
+
+        double scrollbarPosition = horizontalBar.getMax();
+        horizontalBar.setValue(scrollbarPosition);
+
+        assertEquals(scrollbarPosition, horizontalBar.getValue(), 0);
+        horizontalBar.setVisible(false);
+        assertEquals(scrollbarPosition, horizontalBar.getValue(), 0);
+
+        sl.dispose();
+    }
+
     @Test public void test_rt16019() {
         // RT-16019: NodeMemory TableView tests fail with
         // IndexOutOfBoundsException (ObservableListWrapper.java:336)


### PR DESCRIPTION
Clean backport for 8277853

Reviewed-by: kcr, mhanl

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277853](https://bugs.openjdk.org/browse/JDK-8277853): With Touch enabled devices scrollbar disappears and the table is scrolled to the beginning


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.org/jfx17u pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/106.diff">https://git.openjdk.org/jfx17u/pull/106.diff</a>

</details>
