### PR TITLE
8089009: TableView with CONSTRAINED_RESIZE_POLICY incorrectly displays a horizontal scroll bar.

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,11 @@ import javafx.collections.ObservableList;
  * the level of code duplication.
  */
 class TableUtil {
+
+    /**
+     * Constant to consider floating-point arithmetic precision.
+      */
+    private static final double EPSILON = .0000001;
 
     private TableUtil() {
         // no-op
@@ -223,7 +228,7 @@ class TableUtil {
             colWidth += col.getWidth();
         }
 
-        if (Math.abs(colWidth - tableWidth) > 1) {
+        if (Math.abs(colWidth - tableWidth) > EPSILON) {
             isShrinking = colWidth > tableWidth;
             target = tableWidth;
 
@@ -248,7 +253,7 @@ class TableUtil {
                     // finishes early due to a series of "fixed" entries at the end.
                     // In this case, lowerBound == upperBound, for all subsequent terms.
                     double newSize;
-                    if (Math.abs(totalLowerBound - totalUpperBound) < .0000001) {
+                    if (Math.abs(totalLowerBound - totalUpperBound) < EPSILON) {
                         newSize = lowerBound;
                     } else {
                         double f = (target - totalLowerBound) / (totalUpperBound - totalLowerBound);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -5761,4 +5761,52 @@ public class TableViewTest {
         assertEquals(1, anchor.getRow());
         assertEquals(column, anchor.getTableColumn());
     }
+
+    // see JDK-8089009
+    @Test public void testHScrollBarVisibilityForConstrainedTable() {
+        TableColumn firstNameCol = new TableColumn("First Name");
+        firstNameCol.setCellValueFactory(new PropertyValueFactory<Person, String>("firstName"));
+
+        TableColumn lastNameCol = new TableColumn("Last Name");
+        lastNameCol.setCellValueFactory(new PropertyValueFactory<Person, String>("lastName"));
+
+        TableColumn emailCol = new TableColumn("Email");
+        emailCol.setCellValueFactory(new PropertyValueFactory<Person, String>("email"));
+
+        final double initialWidth = 500;
+        TableView<Person> table = new TableView<>(personTestData);
+        table.setMinWidth(initialWidth);
+        table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
+        table.setItems(personTestData);
+        table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+
+        StageLoader sl = new StageLoader(table);
+        Toolkit.getToolkit().firePulse();
+
+        ScrollBar horizontalBar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
+        assertNotNull(horizontalBar);
+        assertEquals(initialWidth, table.getWidth(), 0);
+        assertFalse(horizontalBar.isVisible());
+
+        // Reduce table width by 10px
+        table.setMinWidth(initialWidth - 10);
+        Toolkit.getToolkit().firePulse();
+        assertEquals(initialWidth - 10, table.getWidth(), 0);
+        assertFalse(horizontalBar.isVisible());
+
+        // Reset table width
+        table.setMinWidth(initialWidth);
+        Toolkit.getToolkit().firePulse();
+        assertEquals(initialWidth, table.getWidth(), 0);
+        assertFalse(horizontalBar.isVisible());
+
+        // Reduce table width by 1px
+        table.setMinWidth(initialWidth - 1);
+        Toolkit.getToolkit().firePulse();
+        assertEquals(initialWidth - 1, table.getWidth(), 0);
+        assertFalse(horizontalBar.isVisible());
+
+        sl.dispose();
+    }
+
 }


### PR DESCRIPTION
clean backport of JDK-8089009: TableView with CONSTRAINED_RESIZE_POLICY incorrectly displays a horizontal scroll bar.


Reviewed-by: kcr, angorya, aghaisas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8089009](https://bugs.openjdk.org/browse/JDK-8089009): TableView with CONSTRAINED_RESIZE_POLICY incorrectly displays a horizontal scroll bar.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.org/jfx17u pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/107.diff">https://git.openjdk.org/jfx17u/pull/107.diff</a>

</details>
