### PR TITLE
8296654: [macos] Crash when launching JavaFX app with JDK that targets SDK 13

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -264,7 +264,9 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     (*env)->CallVoidMethod(env, self->jView, jViewNotifyResize, (int)newSize.width, (int)newSize.height);
     GLASS_CHECK_EXCEPTION(env);
 
-    [self->nsView removeTrackingRect:self->trackingRect];
+    if (self->trackingRect) {
+        [self->nsView removeTrackingRect:self->trackingRect];
+    }
     self->trackingRect = [self->nsView addTrackingRect:[self->nsView bounds] owner:self->nsView userData:nil assumeInside:NO];
 }
 
@@ -278,13 +280,17 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     (*env)->CallVoidMethod(env, self->jView, jViewNotifyResize, (int)frameRect.size.width, (int)frameRect.size.height);
     GLASS_CHECK_EXCEPTION(env);
 
-    [self->nsView removeTrackingRect:self->trackingRect];
+    if (self->trackingRect) {
+        [self->nsView removeTrackingRect:self->trackingRect];
+    }
     self->trackingRect = [self->nsView addTrackingRect:[self->nsView bounds] owner:self->nsView userData:nil assumeInside:NO];
 }
 
 - (void)updateTrackingAreas
 {
-    [self->nsView removeTrackingRect:self->trackingRect];
+    if (self->trackingRect) {
+        [self->nsView removeTrackingRect:self->trackingRect];
+    }
     self->trackingRect = [self->nsView addTrackingRect:[self->nsView bounds] owner:self->nsView userData:nil assumeInside:NO];
 }
 


### PR DESCRIPTION
Clean backport to jfx17u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296654](https://bugs.openjdk.org/browse/JDK-8296654): [macos] Crash when launching JavaFX app with JDK that targets SDK 13


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/jfx17u pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/109.diff">https://git.openjdk.org/jfx17u/pull/109.diff</a>

</details>
