### PR TITLE
8301712: [linux] Crash on exit from WebKit 615.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadTimers.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadTimers.cpp
@@ -26,7 +26,9 @@
 
 #include "config.h"
 #include "ThreadTimers.h"
-
+#if PLATFORM(JAVA)
+#include <wtf/java/JavaEnv.h>
+#endif
 #include "MainThreadSharedTimer.h"
 #include "SharedTimer.h"
 #include "ThreadGlobalData.h"
@@ -63,7 +65,11 @@ void ThreadTimers::setSharedTimer(SharedTimer* sharedTimer)
 
     m_sharedTimer = sharedTimer;
 
+#if PLATFORM(JAVA)
+    if (sharedTimer && !g_ShuttingDown) {
+#else
     if (sharedTimer) {
+#endif
         m_sharedTimer->setFiredFunction([] { threadGlobalData().threadTimers().sharedTimerFiredInternal(); });
         updateSharedTimer();
     }


### PR DESCRIPTION
Clean backport. Tested in connection with 3 other WebKit fixes in the `test-kcr-17.0.7` branch, including a successful CI build. I also verfied that the native WebKit code is identical to mainline jfx after applying all patches (excluding a couple of copyright years).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301712](https://bugs.openjdk.org/browse/JDK-8301712): [linux] Crash on exit from WebKit 615.1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.org/jfx17u pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/113.diff">https://git.openjdk.org/jfx17u/pull/113.diff</a>

</details>
