### PR TITLE
8254676: Alert disables Tab selection when TabDragPolicy REORDER is used

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -2102,14 +2102,12 @@ public class TabPaneSkin extends SkinBase<TabPane> {
 
     private void handleHeaderMousePressed(MouseEvent event) {
         if (event.getButton().equals(MouseButton.PRIMARY)) {
-            ((StackPane) event.getSource()).setMouseTransparent(true);
             startDrag(event);
         }
     }
 
     private void handleHeaderMouseReleased(MouseEvent event) {
         if (event.getButton().equals(MouseButton.PRIMARY)) {
-            ((StackPane) event.getSource()).setMouseTransparent(false);
             stopDrag();
             event.consume();
         }


### PR DESCRIPTION
Clean backport of 8254676: Alert disables Tab selection when TabDragPolicy REORDER is used
Reviewed-by: arapte, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254676](https://bugs.openjdk.org/browse/JDK-8254676): Alert disables Tab selection when TabDragPolicy REORDER is used


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/115/head:pull/115` \
`$ git checkout pull/115`

Update a local copy of the PR: \
`$ git checkout pull/115` \
`$ git pull https://git.openjdk.org/jfx17u pull/115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 115`

View PR using the GUI difftool: \
`$ git pr show -t 115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/115.diff">https://git.openjdk.org/jfx17u/pull/115.diff</a>

</details>
