### PR TITLE
8303026: [TextField] IOOBE on setting text with control characters that replaces existing text

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,6 +182,13 @@ public abstract class TextInputControl extends Control {
             } else {
                 int start = sel.getStart();
                 int end = sel.getEnd();
+                int length = txt.length();
+                if (end > start + length) {
+                    end = length;
+                }
+                if (start > length - 1) {
+                    start = end = 0;
+                }
                 selectedText.set(txt.substring(start, end));
             }
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -474,6 +474,13 @@ public class TextFieldTest {
         assertEquals(4, txtField.getSelection().getEnd());
     }
 
+    @Test public void stripInvalidCharacters() {
+        txtField.setText("abcdefghijklm");
+        char[] c = new char[]{0x7F, 0xA, 0x9, 0x00, 0x05, 0x10, 0x19};
+        txtField.setText(String.valueOf(c));
+        assertEquals("", txtField.getText());
+    }
+
     private Change noDigits(Change change) {
         Change filtered = change.clone();
         filtered.setText(change.getText().replaceAll("[0-9]","\n"));


### PR DESCRIPTION
Almost clean backport of JDK-8303026
The test that is part of this backport is added manually, because of the large offset.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303026](https://bugs.openjdk.org/browse/JDK-8303026): [TextField] IOOBE on setting text with control characters that replaces existing text


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/117/head:pull/117` \
`$ git checkout pull/117`

Update a local copy of the PR: \
`$ git checkout pull/117` \
`$ git pull https://git.openjdk.org/jfx17u pull/117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 117`

View PR using the GUI difftool: \
`$ git pr show -t 117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/117.diff">https://git.openjdk.org/jfx17u/pull/117.diff</a>

</details>
