### PR TITLE
8300893: Wrong state after deselecting two or more cells of a TableView selection

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/SizeLimitedList.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/SizeLimitedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package com.sun.javafx.scene.control;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * A list that has a maximum size. Useful for recording historical data, but not
@@ -64,5 +65,13 @@ public class SizeLimitedList<E> {
 
     public boolean contains(E item) {
         return backingList.contains(item);
+    }
+
+    public void clear() {
+        backingList.clear();
+    }
+
+    public void removeIf(Predicate<? super E> predicate) {
+        backingList.removeIf(predicate);
     }
 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,13 +68,17 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
         }
     };
 
-    private final SizeLimitedList<TablePositionBase> selectionHistory = new SizeLimitedList<>(10);
+    private final SizeLimitedList<TablePositionBase> selectionHistory = new SizeLimitedList<>(50);
 
     protected final ListChangeListener<TablePositionBase> selectedCellsListener = c -> {
         while (c.next()) {
             if (c.wasReplaced()) {
                 if (TreeTableCellBehavior.hasDefaultAnchor(getNode())) {
                     TreeTableCellBehavior.removeAnchor(getNode());
+                }
+                if (selectionHistory.size() > 0) {
+                    // whenever the selection is replaced, reset the selection history
+                    resetSelectionHistory();
                 }
             }
 
@@ -253,7 +257,7 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
      */
     protected void setAnchor(TablePositionBase tp) {
         TableCellBehaviorBase.setAnchor(getNode(), tp, false);
-        setSelectionPathDeviated(false);
+        resetSelectionHistory();
     }
 
     /**
@@ -428,6 +432,12 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
 
     private void setSelectionPathDeviated(boolean selectionPathDeviated) {
         this.selectionPathDeviated = selectionPathDeviated;
+    }
+
+    private void resetSelectionHistory() {
+        setSelectionPathDeviated(false);
+        selectionHistory.clear();
+        selectionHistory.add(getAnchor());
     }
 
     protected void scrollUp() {
@@ -706,6 +716,9 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
                     (backtracking ? focusedCellRow : newFocusOwner) :
                     focusedCellRow;
 
+            // remove deselected cell from selection history, if present
+            selectionHistory.removeIf(i -> i.getRow() == cellRowToClear && i.getColumn() == focusedCell.getColumn());
+
             sm.clearSelection(cellRowToClear, focusedCell.getTableColumn());
             fm.focus(newFocusOwner, focusedCell.getTableColumn());
         } else if (isShiftDown && getAnchor() != null && ! selectionPathDeviated) {
@@ -765,9 +778,8 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
 
             // work out if we're backtracking
             boolean backtracking = false;
-            ObservableList<? extends TablePositionBase> selectedCells = getSelectedCells();
-            if (selectedCells.size() >= 2) {
-                TablePositionBase<TC> secondToLastSelectedCell = selectedCells.get(selectedCells.size() - 2);
+            if (selectionHistory.size() >= 2) {
+                TablePositionBase<TC> secondToLastSelectedCell = selectionHistory.get(1);
                 backtracking = secondToLastSelectedCell.getRow() == focusedCellRow &&
                         secondToLastSelectedCell.getTableColumn().equals(adjacentColumn);
             }
@@ -777,6 +789,9 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
             TableColumnBase<?,?> cellColumnToClear = selectionPathDeviated ?
                     (backtracking ? focusedCell.getTableColumn() : adjacentColumn) :
                     focusedCell.getTableColumn();
+
+            // remove deselected cell from selection history, if present
+            selectionHistory.removeIf(i -> i.getRow() == focusedCellRow && i.getTableColumn().equals(cellColumnToClear));
 
             sm.clearSelection(focusedCellRow, cellColumnToClear);
             fm.focus(focusedCellRow, adjacentColumn);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -857,40 +857,149 @@ public class TableViewKeyInputTest {
      * Tests for cell-based multiple selection
      **************************************************************************/
 
-    @Ignore("Bug persists")
     @Test public void testSelectionPathDeviationWorks1() {
         // select horizontally, then select two items vertically, then go back
         // in opposite direction
         sm.setCellSelectionEnabled(true);
         sm.clearAndSelect(1, col0);
 
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col1)
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col2)
-        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col3)
-        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (2, col3)
-        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (3, col3)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (2, col2)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (3, col2)
         assertTrue(sm.isSelected(1, col2));
         assertTrue(sm.isSelected(2, col2));
         assertTrue(sm.isSelected(3, col2));
 
-        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (3, col3)
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (3, col2)
         assertTrue(sm.isSelected(1, col2));
         assertTrue(sm.isSelected(2, col2));
         assertFalse(sm.isSelected(3, col2));
 
-        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (2, col3)
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (2, col2)
         assertTrue(sm.isSelected(1, col2));
         assertFalse(sm.isSelected(2, col2));
         assertFalse(sm.isSelected(3, col2));
 
-        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (1, col3)
-        assertFalse(debug(), sm.isSelected(1, col2));
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);    // deselect (1, col2)
+        assertFalse(sm.isSelected(1, col2));
         assertFalse(sm.isSelected(2, col2));
         assertFalse(sm.isSelected(3, col2));
 
-        keyboard.doLeftArrowPress(KeyModifier.SHIFT);    // deselect (1, col2)
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);    // deselect (1, col1)
         assertFalse(sm.isSelected(1, col1));
     }
 
+    @Test public void testSelectionPathDeviationWorks2() {
+        // select vertically, then select two items horizontally, then go back
+        // in opposite direction
+        sm.setCellSelectionEnabled(true);
+        sm.clearAndSelect(1, col2);
+
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);   // select (2, col2)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);   // select (3, col2)
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // select (3, col1)
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // select (3, col0)
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(1, col2));
+
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);    // deselect (3, col0)
+        assertFalse(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(1, col2));
+
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);    // deselect (3, col1)
+        assertFalse(sm.isSelected(3, col0));
+        assertFalse(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(1, col2));
+
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (3, col2)
+        assertFalse(sm.isSelected(3, col0));
+        assertFalse(sm.isSelected(3, col1));
+        assertFalse(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(1, col2));
+
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (2, col2)
+        assertFalse(sm.isSelected(3, col0));
+        assertFalse(sm.isSelected(3, col1));
+        assertFalse(sm.isSelected(3, col2));
+        assertFalse(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(1, col2));
+    }
+
+    @Test public void testSelectionPathDeviationWorks3() {
+        // select horizontally, then select one item vertically, then start
+        // another selection and go back in opposite direction
+        sm.setCellSelectionEnabled(true);
+        sm.clearAndSelect(1, col0);
+
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col1)
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col2)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (2, col2)
+        assertTrue(sm.isSelected(1, col0));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col2));
+        assertTrue(sm.isSelected(2, col2));
+
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (2, col2)
+        assertTrue(sm.isSelected(1, col0));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col2));
+        assertFalse(sm.isSelected(2, col2));
+
+        // new selection: anchor changes
+        sm.clearAndSelect(3, col0);
+        assertFalse(sm.isSelected(1, col0));
+        assertFalse(sm.isSelected(1, col1));
+        assertFalse(sm.isSelected(1, col2));
+        assertFalse(sm.isSelected(2, col2));
+
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (3, col1)
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (3, col2)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (4, col2)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (5, col2)
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(4, col2));
+        assertTrue(sm.isSelected(5, col2));
+
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (5, col2)
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(4, col2));
+        assertFalse(sm.isSelected(5, col2));
+
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (4, col2)
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertFalse(sm.isSelected(4, col2));
+        assertFalse(sm.isSelected(5, col2));
+
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);    // deselect (3, col2)
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertFalse(sm.isSelected(3, col2));
+        assertFalse(sm.isSelected(4, col2));
+        assertFalse(sm.isSelected(5, col2));
+
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);    // deselect (3, col1)
+        assertTrue(sm.isSelected(3, col0));
+        assertFalse(sm.isSelected(3, col1));
+        assertFalse(sm.isSelected(3, col2));
+        assertFalse(sm.isSelected(4, col2));
+        assertFalse(sm.isSelected(5, col2));
+    }
 
     /***************************************************************************
      * Tests for discontinuous multiple row selection (RT-18951)

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewKeyInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -908,40 +908,149 @@ public class TreeTableViewKeyInputTest {
      * Tests for cell-based multiple selection
      **************************************************************************/
 
-    @Ignore("Bug persists")
     @Test public void testSelectionPathDeviationWorks1() {
         // select horizontally, then select two items vertically, then go back
         // in opposite direction
         sm.setCellSelectionEnabled(true);
         sm.clearAndSelect(1, col0);
 
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col1)
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col2)
-        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col3)
-        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (2, col3)
-        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (3, col3)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (2, col2)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (3, col2)
         assertTrue(sm.isSelected(1, col2));
         assertTrue(sm.isSelected(2, col2));
         assertTrue(sm.isSelected(3, col2));
 
-        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (3, col3)
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (3, col2)
         assertTrue(sm.isSelected(1, col2));
         assertTrue(sm.isSelected(2, col2));
         assertFalse(sm.isSelected(3, col2));
 
-        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (2, col3)
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (2, col2)
         assertTrue(sm.isSelected(1, col2));
         assertFalse(sm.isSelected(2, col2));
         assertFalse(sm.isSelected(3, col2));
 
-        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (1, col3)
-        assertFalse(debug(), sm.isSelected(1, col2));
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);    // deselect (1, col2)
+        assertFalse(sm.isSelected(1, col2));
         assertFalse(sm.isSelected(2, col2));
         assertFalse(sm.isSelected(3, col2));
 
-        keyboard.doLeftArrowPress(KeyModifier.SHIFT);    // deselect (1, col2)
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);    // deselect (1, col1)
         assertFalse(sm.isSelected(1, col1));
     }
 
+    @Test public void testSelectionPathDeviationWorks2() {
+        // select vertically, then select two items horizontally, then go back
+        // in opposite direction
+        sm.setCellSelectionEnabled(true);
+        sm.clearAndSelect(1, col2);
+
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);   // select (2, col2)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);   // select (3, col2)
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // select (3, col1)
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // select (3, col0)
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(1, col2));
+
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);    // deselect (3, col0)
+        assertFalse(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(1, col2));
+
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);    // deselect (3, col1)
+        assertFalse(sm.isSelected(3, col0));
+        assertFalse(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(1, col2));
+
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (3, col2)
+        assertFalse(sm.isSelected(3, col0));
+        assertFalse(sm.isSelected(3, col1));
+        assertFalse(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(1, col2));
+
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (2, col2)
+        assertFalse(sm.isSelected(3, col0));
+        assertFalse(sm.isSelected(3, col1));
+        assertFalse(sm.isSelected(3, col2));
+        assertFalse(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(1, col2));
+    }
+
+    @Test public void testSelectionPathDeviationWorks3() {
+        // select horizontally, then select one item vertically, then start
+        // another selection and go back in opposite direction
+        sm.setCellSelectionEnabled(true);
+        sm.clearAndSelect(1, col0);
+
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col1)
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col2)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (2, col2)
+        assertTrue(sm.isSelected(1, col0));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col2));
+        assertTrue(sm.isSelected(2, col2));
+
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (2, col2)
+        assertTrue(sm.isSelected(1, col0));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col2));
+        assertFalse(sm.isSelected(2, col2));
+
+        // new selection: anchor changes
+        sm.clearAndSelect(3, col0);
+        assertFalse(sm.isSelected(1, col0));
+        assertFalse(sm.isSelected(1, col1));
+        assertFalse(sm.isSelected(1, col2));
+        assertFalse(sm.isSelected(2, col2));
+
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (3, col1)
+        keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (3, col2)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (4, col2)
+        keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (5, col2)
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(4, col2));
+        assertTrue(sm.isSelected(5, col2));
+
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (5, col2)
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertTrue(sm.isSelected(4, col2));
+        assertFalse(sm.isSelected(5, col2));
+
+        keyboard.doUpArrowPress(KeyModifier.SHIFT);    // deselect (4, col2)
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(3, col2));
+        assertFalse(sm.isSelected(4, col2));
+        assertFalse(sm.isSelected(5, col2));
+
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);    // deselect (3, col2)
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertFalse(sm.isSelected(3, col2));
+        assertFalse(sm.isSelected(4, col2));
+        assertFalse(sm.isSelected(5, col2));
+
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT);    // deselect (3, col1)
+        assertTrue(sm.isSelected(3, col0));
+        assertFalse(sm.isSelected(3, col1));
+        assertFalse(sm.isSelected(3, col2));
+        assertFalse(sm.isSelected(4, col2));
+        assertFalse(sm.isSelected(5, col2));
+    }
 
     /***************************************************************************
      * Tests for discontinuous multiple row selection (RT-18951)


### PR DESCRIPTION
Almost clean patch for 
[PATCH] 8300893: Wrong state after deselecting two or more cells of a TableView selection

(required changes in (c) date)

Reviewed-by: aghaisas, angorya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300893](https://bugs.openjdk.org/browse/JDK-8300893): Wrong state after deselecting two or more cells of a TableView selection


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.org/jfx17u pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/120.diff">https://git.openjdk.org/jfx17u/pull/120.diff</a>

</details>
