### PR TITLE
8235491: Tree/TableView: implementation of isSelected(int) violates contract

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SelectionModel.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SelectionModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -198,9 +198,8 @@ public abstract class SelectionModel<T> {
     public abstract void clearSelection();
 
     /**
-     * <p>Convenience method to inform if the given index is currently selected
-     * in this SelectionModel. Is functionally equivalent to calling
-     * <code>getSelectedIndices().contains(index)</code>.
+     * This method tests whether the given index is currently selected
+     * in this SelectionModel.
      *
      * @param index The index to check as to whether it is currently selected
      *      or not.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -2812,10 +2812,6 @@ public class TableView<S> extends Control {
             stopAtomic();
         }
 
-        @Override public boolean isSelected(int index) {
-            return isSelected(index, null);
-        }
-
         @Override
         public boolean isSelected(int row, TableColumn<S,?> column) {
             // When in cell selection mode, if the column is null, then we interpret

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -441,7 +441,7 @@ public class TreeTableRow<T> extends IndexedCell<T> {
         if (index == -1 || getTreeTableView() == null) return;
         if (getTreeTableView().getSelectionModel() == null) return;
 
-        boolean isSelected = getTreeTableView().getSelectionModel().isSelected(index);
+        boolean isSelected = getTreeTableView().getSelectionModel().isSelected(index, null);
         if (isSelected() == isSelected) return;
 
         updateSelected(isSelected);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -3164,10 +3164,6 @@ public class TreeTableView<S> extends Control {
             stopAtomic();
         }
 
-        @Override public boolean isSelected(int index) {
-            return isSelected(index, null);
-        }
-
         @Override public boolean isSelected(int row, TableColumnBase<TreeItem<S>,?> column) {
             // When in cell selection mode, if the column is null, then we interpret
             // the users query to be asking if _all_ of the cells in the row are selected,

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewMouseInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewMouseInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -714,7 +714,7 @@ public class TableViewMouseInputTest {
             assertFalse(sm.isSelected(row, firstNameCol));
             assertFalse(sm.isSelected(row, lastNameCol));
             assertTrue(sm.isSelected(row, emailCol));
-            assertFalse(sm.isSelected(row));
+            assertTrue(sm.isSelected(row));
 
             // and assert that the visuals are accurate
             // (some TableCells should be selected, but TableRows should not be)
@@ -787,7 +787,7 @@ public class TableViewMouseInputTest {
         if (cellSelection) {
             // Because we are in cell selection mode, this has the effect of
             // selecting just the one cell.
-            assertFalse(sm.isSelected(0));
+            assertTrue(sm.isSelected(0));
             assertTrue(sm.isSelected(0, firstNameCol));
             assertFalse(sm.isSelected(0, lastNameCol));
             assertFalse(sm.isSelected(0, emailCol));
@@ -813,7 +813,7 @@ public class TableViewMouseInputTest {
         if (cellSelection) {
             // Everything should remain the same, except the
             // column of the single selected cell should change to lastNameCol.
-            assertFalse(sm.isSelected(0));
+            assertTrue(sm.isSelected(0));
             assertFalse(sm.isSelected(0, firstNameCol));
             assertTrue(sm.isSelected(0, lastNameCol));
             assertFalse(sm.isSelected(0, emailCol));

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewMouseInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewMouseInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -889,7 +889,7 @@ public class TreeTableViewMouseInputTest {
             assertFalse(sm.isSelected(row, firstNameCol));
             assertFalse(sm.isSelected(row, lastNameCol));
             assertTrue(sm.isSelected(row, emailCol));
-            assertFalse(sm.isSelected(row));
+            assertTrue(sm.isSelected(row));
 
             // and assert that the visuals are accurate
             // (some TableCells should be selected, but TableRows should not be)
@@ -966,7 +966,7 @@ public class TreeTableViewMouseInputTest {
         if (cellSelection) {
             // Because we are in cell selection mode, this has the effect of
             // selecting just the one cell.
-            assertFalse(sm.isSelected(0));
+            assertTrue(sm.isSelected(0));
             assertTrue(sm.isSelected(0, firstNameCol));
             assertFalse(sm.isSelected(0, lastNameCol));
             assertFalse(sm.isSelected(0, emailCol));
@@ -992,7 +992,7 @@ public class TreeTableViewMouseInputTest {
         if (cellSelection) {
             // Everything should remain the same, except the
             // column of the single selected cell should change to lastNameCol.
-            assertFalse(sm.isSelected(0));
+            assertTrue(sm.isSelected(0));
             assertFalse(sm.isSelected(0, firstNameCol));
             assertTrue(sm.isSelected(0, lastNameCol));
             assertFalse(sm.isSelected(0, emailCol));


### PR DESCRIPTION
clean backport of
8235491: Tree/TableView: implementation of isSelected(int) violates contract

Reviewed-by: aghaisas, fastegal, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8235491](https://bugs.openjdk.org/browse/JDK-8235491): Tree/TableView: implementation of isSelected(int) violates contract


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.org/jfx17u pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/121.diff">https://git.openjdk.org/jfx17u/pull/121.diff</a>

</details>
