### PR TITLE
8187145: (Tree)TableView with null selectionModel: throws NPE on sorting

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/CellBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/CellBehaviorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -271,15 +271,21 @@ public abstract class CellBehaviorBase<T extends Cell> extends BehaviorBase<T> {
 
     protected void simpleSelect(MouseButton button, int clickCount, boolean shortcutDown) {
         final int index = getIndex();
-        MultipleSelectionModel<?> sm = getSelectionModel();
-        boolean isAlreadySelected = sm.isSelected(index);
+        boolean isAlreadySelected;
 
-        if (isAlreadySelected && shortcutDown) {
-            sm.clearSelection(index);
-            getFocusModel().focus(index);
+        MultipleSelectionModel<?> sm = getSelectionModel();
+        if (sm == null) {
             isAlreadySelected = false;
         } else {
-            sm.clearAndSelect(index);
+            isAlreadySelected = sm.isSelected(index);
+
+            if (isAlreadySelected && shortcutDown) {
+                sm.clearSelection(index);
+                getFocusModel().focus(index);
+                isAlreadySelected = false;
+            } else {
+                sm.clearAndSelect(index);
+            }
         }
 
         handleClicks(button, clickCount, isAlreadySelected);
@@ -300,6 +306,10 @@ public abstract class CellBehaviorBase<T extends Cell> extends BehaviorBase<T> {
     }
 
     void selectRows(int focusedIndex, int index) {
+        if (getSelectionModel() == null) {
+            return;
+        }
+
         final boolean asc = focusedIndex < index;
 
         // and then determine all row and columns which must be selected

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableCellBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableCellBehaviorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,23 +200,30 @@ public abstract class TableCellBehaviorBase<S, T, TC extends TableColumnBase<S, 
 
     protected void simpleSelect(MouseButton button, int clickCount, boolean shortcutDown) {
         final TableSelectionModel<S> sm = getSelectionModel();
-        final int row = getNode().getIndex();
-        final TableColumnBase<S,T> column = getTableColumn();
-        boolean isAlreadySelected = sm.isSelected(row, column);
+        boolean isAlreadySelected;
 
-        if (isAlreadySelected && shortcutDown) {
-            sm.clearSelection(row, column);
-            getFocusModel().focus(row, (TC) column);
+        if (sm == null) {
             isAlreadySelected = false;
         } else {
-            // we check if cell selection is enabled to fix RT-33897
-            sm.clearAndSelect(row, column);
+            final int row = getNode().getIndex();
+            final TableColumnBase<S,T> column = getTableColumn();
+            isAlreadySelected = sm.isSelected(row, column);
+
+            if (isAlreadySelected && shortcutDown) {
+                sm.clearSelection(row, column);
+                getFocusModel().focus(row, (TC) column);
+                isAlreadySelected = false;
+            } else {
+                // we check if cell selection is enabled to fix RT-33897
+                sm.clearAndSelect(row, column);
+            }
         }
 
         handleClicks(button, clickCount, isAlreadySelected);
     }
 
     private int getColumn() {
+        // this method will not be called if selection model is null
         if (getSelectionModel().isCellSelectionEnabled()) {
             TableColumnBase<S,T> tc = getTableColumn();
             return getVisibleLeafIndex(tc);

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehavior.java
@@ -27,6 +27,7 @@ package com.sun.javafx.scene.control.behavior;
 
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumnBase;
@@ -114,7 +115,12 @@ public class TableViewBehavior<T> extends TableViewBehaviorBase<TableView<T>, T,
 
     /** {@inheritDoc}  */
     @Override protected ObservableList<TablePosition> getSelectedCells() {
-        return getNode().getSelectionModel().getSelectedCells();
+        TableViewSelectionModel<T> sm = getNode().getSelectionModel();
+        if (sm == null) {
+            return FXCollections.emptyObservableList();
+        } else {
+            return sm.getSelectedCells();
+        }
     }
 
     /** {@inheritDoc}  */

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeTableViewBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeTableViewBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import static javafx.scene.input.KeyCode.*;
 
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TableColumnBase;
 import javafx.scene.control.TableFocusModel;
@@ -38,6 +39,7 @@ import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTablePosition;
 import javafx.scene.control.TreeTableView;
+import javafx.scene.control.TreeTableView.TreeTableViewSelectionModel;
 import com.sun.javafx.scene.control.inputmap.InputMap;
 import javafx.util.Callback;
 
@@ -121,7 +123,12 @@ public class TreeTableViewBehavior<T> extends TableViewBehaviorBase<TreeTableVie
 
     /** {@inheritDoc}  */
     @Override protected ObservableList<TreeTablePosition<T,?>> getSelectedCells() {
-        return getNode().getSelectionModel().getSelectedCells();
+        TreeTableViewSelectionModel<T> sm = getNode().getSelectionModel();
+        if (sm == null) {
+            return FXCollections.observableArrayList();
+        } else {
+            return sm.getSelectedCells();
+        }
     }
 
     /** {@inheritDoc}  */
@@ -187,7 +194,8 @@ public class TreeTableViewBehavior<T> extends TableViewBehaviorBase<TreeTableVie
      * on whether we are in row or cell selection.
      */
     private void rightArrowPressed() {
-        if (getNode().getSelectionModel().isCellSelectionEnabled()) {
+        TreeTableViewSelectionModel<T> sm = getNode().getSelectionModel();
+        if ((sm != null) && sm.isCellSelectionEnabled()) {
             if (isRTL()) {
                 selectLeftCell();
             } else {
@@ -199,7 +207,8 @@ public class TreeTableViewBehavior<T> extends TableViewBehaviorBase<TreeTableVie
     }
 
     private void leftArrowPressed() {
-        if (getNode().getSelectionModel().isCellSelectionEnabled()) {
+        TreeTableViewSelectionModel<T> sm = getNode().getSelectionModel();
+        if ((sm != null) && sm.isCellSelectionEnabled()) {
             if (isRTL()) {
                 selectRightCell();
             } else {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
@@ -442,6 +442,9 @@ public class TreeTableRow<T> extends IndexedCell<T> {
 
         TreeTableViewSelectionModel<T> sm = getTreeTableView().getSelectionModel();
         if (sm == null) {
+            if (isSelected()) {
+                updateSelected(false);
+            }
             return;
         }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -1069,6 +1069,7 @@ public class TreeTableView<S> extends Control {
                     // need to listen to the cellSelectionEnabledProperty
                     // in order to set pseudo-class state
                     if (oldValue != null) {
+                        oldValue.clearSelection();
                         oldValue.cellSelectionEnabledProperty().removeListener(weakCellSelectionModelInvalidationListener);
 
                         if (oldValue instanceof TreeTableViewArrayListSelectionModel) {
@@ -1078,7 +1079,12 @@ public class TreeTableView<S> extends Control {
 
                     oldValue = get();
 
-                    if (oldValue != null) {
+                    if (oldValue == null) {
+                        // show no focused rows with a null selection model
+                        if (getFocusModel() != null) {
+                            getFocusModel().setFocusedIndex(-1);
+                        }
+                    } else {
                         oldValue.cellSelectionEnabledProperty().addListener(weakCellSelectionModelInvalidationListener);
                         // fake invalidation to ensure updated pseudo-class states
                         weakCellSelectionModelInvalidationListener.invalidated(oldValue.cellSelectionEnabledProperty());
@@ -1848,13 +1854,17 @@ public class TreeTableView<S> extends Control {
             return;
         }
 
-        final List<TreeTablePosition<S,?>> prevState = new ArrayList<>(getSelectionModel().getSelectedCells());
-        final int itemCount = prevState.size();
+        TreeTableViewSelectionModel<S> selectionModel = getSelectionModel();
+        final List<TreeTablePosition<S,?>> prevState = (selectionModel == null) ?
+                null :
+                new ArrayList<>(selectionModel.getSelectedCells());
 
         // we set makeAtomic to true here, so that we don't fire intermediate
         // sort events - instead we send a single permutation event at the end
         // of this method.
-        getSelectionModel().startAtomic();
+        if (selectionModel != null) {
+            selectionModel.startAtomic();
+        }
 
         // get the sort policy and run it
         Callback<TreeTableView<S>, Boolean> sortPolicy = getSortPolicy();
@@ -1864,22 +1874,27 @@ public class TreeTableView<S> extends Control {
         }
         Boolean success = sortPolicy.call(this);
 
-        if (getSortMode() == TreeSortMode.ALL_DESCENDANTS) {
-            Set<TreeItem<S>> sortedParents = new HashSet<>();
-            for (TreeTablePosition<S,?> selectedPosition : prevState) {
-                // This null check is not required ideally.
-                // The selectedPosition.getTreeItem() should always return a valid TreeItem.
-                // But, it is possible to be null due to JDK-8248217.
-                if (selectedPosition.getTreeItem() != null) {
-                    TreeItem<S> parent = selectedPosition.getTreeItem().getParent();
-                    while (parent != null && sortedParents.add(parent)) {
-                        parent.getChildren();
-                        parent = parent.getParent();
+        if (prevState != null) {
+            if (getSortMode() == TreeSortMode.ALL_DESCENDANTS) {
+                Set<TreeItem<S>> sortedParents = new HashSet<>();
+                for (TreeTablePosition<S,?> selectedPosition : prevState) {
+                    // This null check is not required ideally.
+                    // The selectedPosition.getTreeItem() should always return a valid TreeItem.
+                    // But, it is possible to be null due to JDK-8248217.
+                    if (selectedPosition.getTreeItem() != null) {
+                        TreeItem<S> parent = selectedPosition.getTreeItem().getParent();
+                        while (parent != null && sortedParents.add(parent)) {
+                            parent.getChildren();
+                            parent = parent.getParent();
+                        }
                     }
                 }
             }
         }
-        getSelectionModel().stopAtomic();
+
+        if (selectionModel != null) {
+            selectionModel.stopAtomic();
+        }
 
         if (success == null || ! success) {
             // the sort was a failure. Need to backout if possible
@@ -1892,29 +1907,36 @@ public class TreeTableView<S> extends Control {
             // selection model that the items list has 'permutated' to a new ordering
 
             // FIXME we should support alternative selection model implementations!
-            if (getSelectionModel() instanceof TreeTableViewArrayListSelectionModel) {
-                final TreeTableViewArrayListSelectionModel<S> sm = (TreeTableViewArrayListSelectionModel<S>) getSelectionModel();
+            if (selectionModel instanceof TreeTableViewArrayListSelectionModel) {
+                final TreeTableViewArrayListSelectionModel<S> sm = (TreeTableViewArrayListSelectionModel<S>)selectionModel;
                 final ObservableList<TreeTablePosition<S, ?>> newState = sm.getSelectedCells();
 
                 List<TreeTablePosition<S, ?>> removed = new ArrayList<>();
-                for (int i = 0; i < itemCount; i++) {
-                    TreeTablePosition<S, ?> prevItem = prevState.get(i);
-                    if (!newState.contains(prevItem)) {
-                        removed.add(prevItem);
+                if (prevState != null) {
+                    for (TreeTablePosition<S, ?> prevItem: prevState) {
+                        if (!newState.contains(prevItem)) {
+                            removed.add(prevItem);
+                        }
                     }
                 }
+
                 if (!removed.isEmpty()) {
                     // the sort operation effectively permutates the selectedCells list,
                     // but we cannot fire a permutation event as we are talking about
                     // TreeTablePosition's changing (which may reside in the same list
                     // position before and after the sort). Therefore, we need to fire
                     // a single add/remove event to cover the added and removed positions.
+                    int itemCount = prevState == null ? 0 : prevState.size();
                     ListChangeListener.Change<TreeTablePosition<S, ?>> c = new NonIterableChange.GenericAddRemoveChange<>(0, itemCount, removed, newState);
                     sm.fireCustomSelectedCellsListChangeEvent(c);
                 }
             }
-            getSelectionModel().setSelectedIndex(getRow(getSelectionModel().getSelectedItem()));
-            getFocusModel().focus(getSelectionModel().getSelectedIndex());
+
+            if (selectionModel != null) {
+                selectionModel.setSelectedIndex(getRow(selectionModel.getSelectedItem()));
+            }
+
+            getFocusModel().focus(selectionModel == null ? -1 : selectionModel.getSelectedIndex());
         }
         sortingInProgress = false;
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkin.java
@@ -157,22 +157,25 @@ public class TableRowSkin<T> extends TableRowSkinBase<T, TableRow<T>, TableCell<
     @Override protected Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
         switch (attribute) {
             case SELECTED_ITEMS: {
-                // FIXME this could be optimised to iterate over cellsMap only
-                // (selectedCells could be big, cellsMap is much smaller)
-                List<Node> selection = new ArrayList<>();
-                int index = getSkinnable().getIndex();
-                for (TablePosition<T,?> pos : getTableView().getSelectionModel().getSelectedCells()) {
-                    if (pos.getRow() == index) {
-                        TableColumn<T,?> column = pos.getTableColumn();
-                        if (column == null) {
-                            /* This is the row-based case */
-                            column = getTableView().getVisibleLeafColumn(0);
+                if (getTableView().getSelectionModel() != null) {
+                    // FIXME this could be optimised to iterate over cellsMap only
+                    // (selectedCells could be big, cellsMap is much smaller)
+                    List<Node> selection = new ArrayList<>();
+                    int index = getSkinnable().getIndex();
+                    for (TablePosition<T,?> pos : getTableView().getSelectionModel().getSelectedCells()) {
+                        if (pos.getRow() == index) {
+                            TableColumn<T,?> column = pos.getTableColumn();
+                            if (column == null) {
+                                /* This is the row-based case */
+                                column = getTableView().getVisibleLeafColumn(0);
+                            }
+                            TableCell<T,?> cell = cellsMap.get(column).get();
+                            if (cell != null) selection.add(cell);
                         }
-                        TableCell<T,?> cell = cellsMap.get(column).get();
-                        if (cell != null) selection.add(cell);
+                        return FXCollections.observableArrayList(selection);
                     }
-                    return FXCollections.observableArrayList(selection);
                 }
+                return FXCollections.observableArrayList();
             }
             case CELL_AT_ROW_COLUMN: {
                 int colIndex = (Integer)parameters[1];
@@ -195,7 +198,8 @@ public class TableRowSkin<T> extends TableRowSkinBase<T, TableRow<T>, TableCell<
                 }
                 return null;
             }
-            default: return super.queryAccessibleAttribute(attribute, parameters);
+            default:
+                return super.queryAccessibleAttribute(attribute, parameters);
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
@@ -159,9 +159,11 @@ public class TableViewSkin<T> extends TableViewSkinBase<T, T, TableView<T>, Tabl
             case SELECTED_ITEMS: {
                 List<Node> selection = new ArrayList<>();
                 TableViewSelectionModel<T> sm = getSkinnable().getSelectionModel();
-                for (TablePosition<T,?> pos : sm.getSelectedCells()) {
-                    TableRow<T> row = flow.getPrivateCell(pos.getRow());
-                    if (row != null) selection.add(row);
+                if (sm != null) {
+                    for (TablePosition<T,?> pos : sm.getSelectedCells()) {
+                        TableRow<T> row = flow.getPrivateCell(pos.getRow());
+                        if (row != null) selection.add(row);
+                    }
                 }
                 return FXCollections.observableArrayList(selection);
             }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -805,6 +805,10 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
 
     private boolean isLeadIndex(boolean isFocusDriven, int index) {
         final TableSelectionModel<S> sm = getSelectionModel();
+        if (sm == null) {
+            return false;
+        }
+
         final FocusModel<M> fm = getFocusModel();
 
         return (isFocusDriven && fm.getFocusedIndex() == index)
@@ -1045,5 +1049,4 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
             default: return super.queryAccessibleAttribute(attribute, parameters);
         }
     }
-
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
@@ -459,22 +459,25 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
         final TreeTableView<T> treeTableView = getSkinnable().getTreeTableView();
         switch (attribute) {
             case SELECTED_ITEMS: {
-                // FIXME this could be optimised to iterate over cellsMap only
-                // (selectedCells could be big, cellsMap is much smaller)
-                List<Node> selection = new ArrayList<>();
-                int index = getSkinnable().getIndex();
-                for (TreeTablePosition<T,?> pos : treeTableView.getSelectionModel().getSelectedCells()) {
-                    if (pos.getRow() == index) {
-                        TreeTableColumn<T,?> column = pos.getTableColumn();
-                        if (column == null) {
-                            /* This is the row-based case */
-                            column = treeTableView.getVisibleLeafColumn(0);
+                if (treeTableView.getSelectionModel() != null) {
+                    // FIXME this could be optimised to iterate over cellsMap only
+                    // (selectedCells could be big, cellsMap is much smaller)
+                    List<Node> selection = new ArrayList<>();
+                    int index = getSkinnable().getIndex();
+                    for (TreeTablePosition<T,?> pos : treeTableView.getSelectionModel().getSelectedCells()) {
+                        if (pos.getRow() == index) {
+                            TreeTableColumn<T,?> column = pos.getTableColumn();
+                            if (column == null) {
+                                /* This is the row-based case */
+                                column = treeTableView.getVisibleLeafColumn(0);
+                            }
+                            TreeTableCell<T,?> cell = cellsMap.get(column).get();
+                            if (cell != null) selection.add(cell);
                         }
-                        TreeTableCell<T,?> cell = cellsMap.get(column).get();
-                        if (cell != null) selection.add(cell);
+                        return FXCollections.observableArrayList(selection);
                     }
-                    return FXCollections.observableArrayList(selection);
                 }
+                return FXCollections.observableArrayList();
             }
             case CELL_AT_ROW_COLUMN: {
                 int colIndex = (Integer)parameters[1];
@@ -497,7 +500,8 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
                 }
                 return null;
             }
-            default: return super.queryAccessibleAttribute(attribute, parameters);
+            default:
+                return super.queryAccessibleAttribute(attribute, parameters);
         }
     }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
@@ -225,9 +225,11 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
             case SELECTED_ITEMS: {
                 List<Node> selection = new ArrayList<>();
                 TreeTableView.TreeTableViewSelectionModel<T> sm = getSkinnable().getSelectionModel();
-                for (TreeTablePosition<T,?> pos : sm.getSelectedCells()) {
-                    TreeTableRow<T> row = flow.getPrivateCell(pos.getRow());
-                    if (row != null) selection.add(row);
+                if (sm != null) {
+                    for (TreeTablePosition<T,?> pos : sm.getSelectedCells()) {
+                        TreeTableRow<T> row = flow.getPrivateCell(pos.getRow());
+                        if (row != null) selection.add(row);
+                    }
                 }
                 return FXCollections.observableArrayList(selection);
             }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -64,6 +64,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
 import javafx.event.EventHandler;
 import javafx.geometry.Orientation;
+import javafx.scene.AccessibleAttribute;
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.control.cell.*;
@@ -115,7 +116,6 @@ import test.com.sun.javafx.scene.control.test.Person;
 import test.com.sun.javafx.scene.control.test.RT_22463_Person;
 
 import javafx.scene.control.skin.TableHeaderRowShim;
-import static org.junit.Assert.assertEquals;
 import test.com.sun.javafx.scene.control.infrastructure.TableColumnHeaderUtil;
 
 public class TableViewTest {
@@ -5939,5 +5939,29 @@ public class TableViewTest {
         // Verify that the arrow is fully visible, and it is not overlapped
         // by the corner region
         assertTrue(arrowMaxX < cornerMinX);
+    }
+
+    @Test
+    public void testQueryAccessibleAttributeSelectedItemsWithNullSelectionModel() {
+        table.getItems().addAll("1", "2");
+        table.setSelectionModel(null);
+        stageLoader = new StageLoader(table);
+
+        Object result = table.queryAccessibleAttribute(AccessibleAttribute.SELECTED_ITEMS);
+        // Should be an empty observable array list
+        assertEquals(FXCollections.observableArrayList(), result);
+    }
+
+    @Ignore("JDK-8296413")
+    @Test
+    public void testQueryAccessibleAttributeFocusItemWithNullFocusModel() {
+        table.getItems().addAll("1", "2");
+        table.setFocusModel(null);
+
+        stageLoader = new StageLoader(table);
+
+        Object result = table.queryAccessibleAttribute(AccessibleAttribute.FOCUS_ITEM);
+
+        assertNull(result);
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeAndTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeAndTableViewTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import com.sun.javafx.tk.Toolkit;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.css.PseudoClass;
+import javafx.event.EventTarget;
+import javafx.scene.Node;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TableView.TableViewSelectionModel;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableView;
+import javafx.scene.control.TreeTableView.TreeTableViewSelectionModel;
+import javafx.scene.control.skin.TableColumnHeader;
+import javafx.scene.input.MouseEvent;
+import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
+import test.com.sun.javafx.scene.control.infrastructure.MouseEventFirer;
+import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
+
+/**
+ * Tests for:
+ * - NPE with null selection model JDK-8187145
+ */
+public class TreeAndTableViewTest {
+    /** Sorting TableView with a null selection model should not generate an NPE */
+    @Test
+    public void test_TableView_jdk_8187145() {
+        TableView<String> table = new TableView<>();
+        table.requestFocus();
+        table.getColumns().addAll(
+            createTableColumn("C0"),
+            createTableColumn("C1"),
+            createTableColumn("C2")
+            );
+        table.getItems().addAll(
+            "",
+            "",
+            ""
+            );
+
+        // important: actually creates cells
+        VirtualFlowTestUtils.getCell(table, 0);
+
+        // row selection mode
+        TableViewSelectionModel<String> oldSelectionModel = table.getSelectionModel();
+        table.getSelectionModel().selectAll();
+        table.setSelectionModel(null);
+
+        // verify none have 'selected' pseudostyle
+        {
+            List cells = table.lookupAll(".table-cell").
+                stream().
+                filter((n) -> ((n instanceof TableCell) && containsPseudoclass(n, "selected"))).
+                collect(Collectors.toList());
+            assertEquals(0, cells.size());
+        }
+
+        // cell selection mode
+        table.setSelectionModel(oldSelectionModel);
+        table.getSelectionModel().setCellSelectionEnabled(true);
+        table.getSelectionModel().selectAll();
+        table.setSelectionModel(null);
+
+        // verify none have 'selected' pseudostyle
+        {
+            List cells = table.lookupAll(".table-cell").
+                stream().
+                filter((n) -> ((n instanceof TableCell) && containsPseudoclass(n, "selected"))).
+                collect(Collectors.toList());
+            assertEquals(0, cells.size());
+        }
+
+        // verify no NPE when sorting by clicking on every table column cell,
+        // toggling sorting ascending -> descending -> none
+        {
+            for (Object x: table.lookupAll(".table-column")) {
+                if (x instanceof TableColumnHeader n) {
+                    mouseClick(n);
+                    assertEquals(1, table.getSortOrder().size());
+                    table.sort();
+
+                    mouseClick(n);
+                    assertEquals(1, table.getSortOrder().size());
+                    table.sort();
+
+                    mouseClick(n);
+                    assertEquals(0, table.getSortOrder().size());
+                    table.sort();
+                }
+            }
+        }
+    }
+
+    /** Sorting TreeTableView with a null selection model should not generate an NPE */
+    @Test
+    public void test_TreeTableView_jdk_8187145() {
+        TreeItem<String> root = new TreeItem<String>("");
+        root.setExpanded(true);
+        root.getChildren().setAll(
+            new TreeItem<>(""),
+            new TreeItem<>(""),
+            new TreeItem<>("")
+            );
+
+        TreeTableView<String> tree = new TreeTableView<>();
+        tree.setRoot(root);
+        tree.setShowRoot(false);
+        tree.requestFocus();
+        tree.getColumns().addAll(
+            createTreeTableColumn("C0"),
+            createTreeTableColumn("C1"),
+            createTreeTableColumn("C2")
+            );
+
+        // important: actually creates cells
+        VirtualFlowTestUtils.getCell(tree, 0);
+
+        // row selection mode
+        TreeTableViewSelectionModel<String> oldSelectionModel = tree.getSelectionModel();
+        tree.getSelectionModel().selectAll();
+        tree.setSelectionModel(null);
+
+        // verify none have 'selected' pseudostyle
+        {
+            List cells = tree.lookupAll(".table-cell").
+                stream().
+                filter((n) -> ((n instanceof TableCell) && containsPseudoclass(n, "selected"))).
+                collect(Collectors.toList());
+            assertEquals(0, cells.size());
+        }
+
+        // cell selection mode
+        tree.setSelectionModel(oldSelectionModel);
+        tree.getSelectionModel().setCellSelectionEnabled(true);
+        tree.getSelectionModel().selectAll();
+        tree.setSelectionModel(null);
+
+        // verify none have 'selected' pseudostyle
+        {
+            List cells = tree.lookupAll(".table-cell").
+                stream().
+                filter((n) -> ((n instanceof TableCell) && containsPseudoclass(n, "selected"))).
+                collect(Collectors.toList());
+            assertEquals(0, cells.size());
+        }
+
+        // verify no NPE when sorting by clicking on every table column cell,
+        // toggling sorting ascending -> descending -> none
+        {
+            for (Object x: tree.lookupAll(".table-column")) {
+                if (x instanceof TableColumnHeader n) {
+                    mouseClick(n);
+                    assertEquals(1, tree.getSortOrder().size());
+                    tree.sort();
+
+                    mouseClick(n);
+                    assertEquals(1, tree.getSortOrder().size());
+                    tree.sort();
+
+                    mouseClick(n);
+                    assertEquals(0, tree.getSortOrder().size());
+                    tree.sort();
+                }
+            }
+        }
+    }
+
+    protected static TreeTableColumn createTreeTableColumn(String name) {
+        TreeTableColumn c = new TreeTableColumn(name);
+        c.setCellValueFactory((f) -> new SimpleStringProperty("..."));
+        return c;
+    }
+
+    protected static void mouseClick(EventTarget t, KeyModifier... modifiers) {
+        MouseEventFirer m = new MouseEventFirer(t);
+        m.fireMousePressAndRelease(modifiers);
+        m.fireMouseEvent(MouseEvent.MOUSE_RELEASED, modifiers);
+        m.dispose();
+
+        Toolkit.getToolkit().firePulse();
+    }
+
+    protected static TableColumn createTableColumn(String name) {
+        TableColumn c = new TableColumn(name);
+        c.setCellValueFactory((f) -> new SimpleStringProperty("..."));
+        return c;
+    }
+
+    protected static <T extends Node> List<T> collectNodes(Node root, String selector, Class<T> type) {
+        return (List<T>)root.
+            lookupAll(selector).
+            stream().
+            filter((n) -> (n.getClass().isAssignableFrom(type))).
+            collect(Collectors.toList());
+    }
+
+    protected static boolean containsPseudoclass(Node n, String pseudoclass) {
+        for (PseudoClass pc : n.getPseudoClassStates()) {
+            if (pseudoclass.equals(pc.getPseudoClassName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -74,6 +74,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
+import javafx.scene.AccessibleAttribute;
 import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.Scene;
@@ -7086,5 +7087,29 @@ public class TreeTableViewTest {
         // Verify that the arrow is fully visible, and it is not overlapped
         // by the corner region
         assertTrue(arrowMaxX < cornerMinX);
+    }
+
+    @Test
+    public void testQueryAccessibleAttributeSelectedItemsWithNullSelectionModel() {
+        treeTableView.setSelectionModel(null);
+        stageLoader = new StageLoader(treeTableView);
+
+        Object result = treeTableView.queryAccessibleAttribute(AccessibleAttribute.SELECTED_ITEMS);
+        // Should be an empty observable array list
+        assertEquals(FXCollections.observableArrayList(), result);
+    }
+
+    @Ignore("JDK-8296413")
+    @Test
+    public void testQueryAccessibleAttributeFocusItemWithNullFocusModel() {
+        treeTableView.setSelectionModel(null);
+        stageLoader = new StageLoader(treeTableView);
+
+        Object result = treeTableView.queryAccessibleAttribute(AccessibleAttribute.FOCUS_ITEM);
+
+        // TODO it seems to return a Label; possibly the placeholder label.
+        // we need to check whether it's what is expected, whether TableView should use the same logic
+        // And also check whether it *is* a placeholder label, see TreeTableView:2146
+        assertNull(result);
     }
 }


### PR DESCRIPTION
Almost clean (apart from some offsets) backport of

8187145: (Tree)TableView with null selectionModel: throws NPE on sorting

Reviewed-by: aghaisas, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8187145](https://bugs.openjdk.org/browse/JDK-8187145): (Tree)TableView with null selectionModel: throws NPE on sorting


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.org/jfx17u pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/123.diff">https://git.openjdk.org/jfx17u/pull/123.diff</a>

</details>
