### PR TITLE
8304098: [testbug] Test compilation failure in ControlUtils.java after JDK-8292353

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlUtils.java
@@ -107,7 +107,8 @@ public class ControlUtils {
     public static TreeTableCell getTreeTableCell(TreeTableView t, int row, int column) {
         TreeTableColumn col = (TreeTableColumn)t.getColumns().get(column);
         return findTheOnly(t, ".tree-table-cell", TreeTableCell.class, (n) -> {
-            if (n instanceof TreeTableCell c) {
+            if (n instanceof TreeTableCell) {
+                TreeTableCell c = (TreeTableCell)n;
                 if (row == c.getTableRow().getIndex()) {
                     if (col == c.getTableColumn()) {
                         return true;
@@ -124,7 +125,8 @@ public class ControlUtils {
      */
     public static TreeTableRow getTreeTableRow(TreeTableView t, int row) {
         return findTheOnly(t, ".tree-table-row-cell", TreeTableRow.class, (n) -> {
-            if (n instanceof TreeTableRow c) {
+            if (n instanceof TreeTableRow) {
+                TreeTableRow c = (TreeTableRow)n;
                 if (row == c.getIndex()) {
                     return true;
                 }
@@ -140,7 +142,8 @@ public class ControlUtils {
     public static TableCell getTableCell(TableView t, int row, int column) {
         TableColumn col = (TableColumn)t.getColumns().get(column);
         return findTheOnly(t, ".table-cell", TableCell.class, (x) -> {
-            if (x instanceof TableCell c) {
+            if (x instanceof TableCell) {
+                TableCell c = (TableCell)x;
                 if (row == c.getTableRow().getIndex()) {
                     if (col == c.getTableColumn()) {
                         return true;
@@ -157,7 +160,8 @@ public class ControlUtils {
      */
     public static TableRow getTableRow(TableView t, int row) {
         return findTheOnly(t, ".table-row-cell", TableRow.class, (x) -> {
-            if (x instanceof TableRow c) {
+            if (x instanceof TableRow) {
+                TableRow c = (TableRow)x;
                 if (row == c.getIndex()) {
                     return true;
                 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeAndTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeAndTableViewTest.java
@@ -105,7 +105,8 @@ public class TreeAndTableViewTest {
         // toggling sorting ascending -> descending -> none
         {
             for (Object x: table.lookupAll(".table-column")) {
-                if (x instanceof TableColumnHeader n) {
+                if (x instanceof TableColumnHeader) {
+                    TableColumnHeader n = (TableColumnHeader)x;
                     mouseClick(n);
                     assertEquals(1, table.getSortOrder().size());
                     table.sort();
@@ -179,7 +180,8 @@ public class TreeAndTableViewTest {
         // toggling sorting ascending -> descending -> none
         {
             for (Object x: tree.lookupAll(".table-column")) {
-                if (x instanceof TableColumnHeader n) {
+                if (x instanceof TableColumnHeader) {
+                    TableColumnHeader n = (TableColumnHeader)x;
                     mouseClick(n);
                     assertEquals(1, tree.getSortOrder().size());
                     tree.sort();


### PR DESCRIPTION
Remove new instanceof pattern (which is not supported in 11)
Fix JDK-8304098

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304098](https://bugs.openjdk.org/browse/JDK-8304098): [testbug] Test compilation failure in ControlUtils.java after JDK-8292353


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u pull/129/head:pull/129` \
`$ git checkout pull/129`

Update a local copy of the PR: \
`$ git checkout pull/129` \
`$ git pull https://git.openjdk.org/jfx17u pull/129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 129`

View PR using the GUI difftool: \
`$ git pr show -t 129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/129.diff">https://git.openjdk.org/jfx17u/pull/129.diff</a>

</details>
