### PR TITLE
8306115: Update libxml2 to 2.10.4

### DIFF
--- a/modules/javafx.web/src/main/legal/libxml2.md
+++ b/modules/javafx.web/src/main/legal/libxml2.md
@@ -1,4 +1,4 @@
-## xmlsoft.org: libxml2 v2.10.3
+## xmlsoft.org: libxml2 v2.10.4
 
 ### libxml2 License
 ```

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/config.h
@@ -160,7 +160,7 @@
 #define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxml2 2.10.3"
+#define PACKAGE_STRING "libxml2 2.10.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxml2"
@@ -169,7 +169,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.10.3"
+#define PACKAGE_VERSION "2.10.4"
 
 /* Type cast for the send() function 2nd arg */
 #define SEND_ARG2_CAST /**/
@@ -186,7 +186,7 @@
 #define VA_LIST_IS_ARRAY 1
 
 /* Version number of package */
-#define VERSION "2.10.3"
+#define VERSION "2.10.4"
 
 /* Determine what socket length (socklen_t) data type is */
 #define XML_SOCKLEN_T socklen_t

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.10.3"
+#define LIBXML_DOTTED_VERSION "2.10.4"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21003
+#define LIBXML_VERSION 21004
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21003"
+#define LIBXML_VERSION_STRING "21004"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21003);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21004);
 
 #ifndef VMS
 #if 0

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/config.h
@@ -160,7 +160,7 @@
 #define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxml2 2.10.3"
+#define PACKAGE_STRING "libxml2 2.10.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxml2"
@@ -169,7 +169,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.10.3"
+#define PACKAGE_VERSION "2.10.4"
 
 /* Type cast for the send() function 2nd arg */
 #define SEND_ARG2_CAST /**/
@@ -186,7 +186,7 @@
 #define VA_LIST_IS_ARRAY 1
 
 /* Version number of package */
-#define VERSION "2.10.3"
+#define VERSION "2.10.4"
 
 /* Determine what socket length (socklen_t) data type is */
 #define XML_SOCKLEN_T socklen_t

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.10.3"
+#define LIBXML_DOTTED_VERSION "2.10.4"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21003
+#define LIBXML_VERSION 21004
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21003"
+#define LIBXML_VERSION_STRING "21004"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21003);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21004);
 
 #ifndef VMS
 #if 0

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
@@ -1,5 +1,19 @@
 NEWS file for libxml2
 
+v2.10.4: Apr 11 2023
+
+### Security
+
+- [CVE-2023-29469] Hashing of empty dict strings isn't deterministic
+- [CVE-2023-28484] Fix null deref in xmlSchemaFixupComplexType
+- schemas: Fix null-pointer-deref in xmlSchemaCheckCOSSTDerivedOK
+
+### Regressions
+
+- SAX2: Ignore namespaces in HTML documents
+- io: Fix "buffer full" error with certain buffer sizes
+
+
 v2.10.3: Oct 14 2022
 
 ### Security
@@ -59,6 +73,47 @@ v2.10.1: Aug 25 2022
 
 
 v2.10.0: Aug 17 2022
+
+### Breaking changes
+
+The Docbook parser module and all related symbols habe been removed completely.
+This was experimental code which never worked and generated a deprecation
+warning for 15+ years. The library's soname wasn't changed in order to allow
+seamless upgrades to later versions. If this concerns you, consider bumping
+soname yourself.
+
+Some other modules are now disabled by default and will eventually be removed
+completely:
+
+- Support for XPointer locations (ranges and points): This was based on
+  a W3C specification which never got beyond Working Draft status. To my
+  knowledge, there's no software supporting this spec which is still
+  maintained. You now have to enable this code by passing the
+  `--with-xptr-locs` configuration option. Be warned that this part of
+  the code base is buggy and had many security issues in the past.
+
+- Support for the built-in FTP client (`--with-ftp`).
+
+- Support for "legacy" functions (`--with-legacy`).
+
+If you're concerned about ABI stability and haven't disabled these modules
+already, add the following configuration options or bump soname yourself:
+
+    --with-ftp
+    --with-legacy
+    --with-xptr-locs
+
+Several functions of the public API were deprecated. Most of them should be
+completely unused and will generate a deprecation warning now.
+
+The autoconf build now uses the sysconfdir variable for the location of
+the default catalog file. The path changed from hardcoded /etc/xml/catalog
+to ${sysconfdir}/xml/catalog. The sysconfdir variable defaults to
+${prefix}/etc, prefix defaults to /usr/local, so without other options
+the path becomes /usr/local/etc/xml/catalog. If you want the old behavior,
+configure with
+
+    --sysconfdir=/etc
 
 ### Security
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/SAX2.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/SAX2.c
@@ -1608,12 +1608,15 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
         ctxt->validate = 0;
     }
 
-
-    /*
-     * Split the full name into a namespace prefix and the tag name
-     */
-    name = xmlSplitQName(ctxt, fullname, &prefix);
-
+    if (ctxt->html) {
+        prefix = NULL;
+        name = xmlStrdup(fullname);
+    } else {
+        /*
+         * Split the full name into a namespace prefix and the tag name
+         */
+        name = xmlSplitQName(ctxt, fullname, &prefix);
+    }
 
     /*
      * Note : the namespace resolution is deferred until the end of the

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/configure.ac
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.63])
 
 m4_define([MAJOR_VERSION], 2)
 m4_define([MINOR_VERSION], 10)
-m4_define([MICRO_VERSION], 3)
+m4_define([MICRO_VERSION], 4)
 
 AC_INIT([libxml2],[MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION])
 AC_CONFIG_SRCDIR([entities.c])

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/dict.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/dict.c
@@ -453,7 +453,8 @@ static unsigned long
 xmlDictComputeFastKey(const xmlChar *name, int namelen, int seed) {
     unsigned long value = seed;
 
-    if (name == NULL) return(0);
+    if ((name == NULL) || (namelen <= 0))
+        return(value);
     value += *name;
     value <<= 5;
     if (namelen > 10) {

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml2.spec
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml2.spec
@@ -2,7 +2,7 @@
 
 Summary: Library providing XML and HTML support
 Name: libxml2
-Version: 2.10.3
+Version: 2.10.4
 Release: 1%{?dist}%{?extra_release}
 License: MIT
 Group: Development/Libraries
@@ -203,6 +203,6 @@ rm -fr %{buildroot}
 %endif # with_python3
 
 %changelog
-* Thu Mar  9 2023 Daniel Veillard <veillard@redhat.com>
-- upstream release 2.10.3
+* Thu Apr 20 2023 Daniel Veillard <veillard@redhat.com>
+- upstream release 2.10.4
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlIO.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlIO.c
@@ -3234,12 +3234,6 @@ xmlParserInputBufferGrow(xmlParserInputBufferPtr in, int len) {
     if ((len <= MINLEN) && (len != 4))
         len = MINLEN;
 
-    if (xmlBufAvail(in->buffer) <= 0) {
-        xmlIOErr(XML_IO_BUFFER_FULL, NULL);
-        in->error = XML_IO_BUFFER_FULL;
-        return(-1);
-    }
-
     if (xmlBufGrow(in->buffer, len + 1) < 0) {
         xmlIOErrMemory("growing input buffer");
         in->error = XML_ERR_NO_MEMORY;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.10.3"
+#define LIBXML_DOTTED_VERSION "2.10.4"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21003
+#define LIBXML_VERSION 21004
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21003"
+#define LIBXML_VERSION_STRING "21004"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21003);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21004);
 
 #ifndef VMS
 #if 0


### PR DESCRIPTION
Clean backport of 
8306115: Update libxml2 to 2.10.4
Reviewed-by: kcr, sykora

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306115](https://bugs.openjdk.org/browse/JDK-8306115): Update libxml2 to 2.10.4 (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/133.diff">https://git.openjdk.org/jfx17u/pull/133.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/133#issuecomment-1598798592)