### PR TITLE
8313177: Web Workers timeout with Webkit 616.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadTimers.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadTimers.cpp
@@ -105,13 +105,6 @@ void ThreadTimers::updateSharedTimer()
 void ThreadTimers::sharedTimerFiredInternal()
 {
     ASSERT(isMainThread() || (!isWebThread() && !isUIThread()));
-
-#if PLATFORM(JAVA)
-    if(!isMainThread()) {
-        return;
-    }
-#endif
-
     // Do a re-entrancy check.
     if (m_firingTimers)
         return;

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/WebWorkerTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/WebWorkerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import javafx.concurrent.Worker.State;
+
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Test;
+import java.io.File;
+import java.io.IOException;
+import javafx.scene.web.WebView;
+import javafx.scene.web.WebEngine;
+
+public class WebWorkerTest extends TestBase {
+
+    private State getLoadState() {
+        return submit(() -> getEngine().getLoadWorker().getState());
+    }
+
+    @Test
+    public void testWorker() throws InterruptedException {
+        final WebEngine webEngine = getEngine();
+        webEngine.setJavaScriptEnabled(true);
+        load(new File("src/test/resources/test/html/worker.html"));
+        assertTrue("Load task completed successfully", getLoadState() == State.SUCCEEDED);
+
+        Thread.sleep(500);
+
+        submit(() -> {
+            WebView view = getView();
+            String res = (String) view.getEngine().executeScript("document.getElementById('result').innerText;");
+            assertEquals("4", res);
+        });
+    }
+}

--- a/modules/javafx.web/src/test/resources/test/html/worker.html
+++ b/modules/javafx.web/src/test/resources/test/html/worker.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body onload="startWorker()">
+
+<p id="result"></p>
+
+<script>
+
+var work;
+
+function startWorker() {
+  if (typeof(Worker) !== "undefined") {
+    if (typeof(work) == "undefined") {
+      work = new Worker("worker.js");
+    }
+    work.onmessage = function(event) {
+      document.getElementById("result").innerHTML = event.data;
+    };
+  }
+}
+
+function stopWorker() {
+  work.terminate();
+  work = undefined;
+}
+
+</script>
+
+</body>
+</html>
+

--- a/modules/javafx.web/src/test/resources/test/html/worker.js
+++ b/modules/javafx.web/src/test/resources/test/html/worker.js
@@ -1,0 +1,17 @@
+/* simple worker module to test*/
+
+var i = 0;
+let timeoutID;
+
+function doIncrement() {
+  i = i + 1;
+  postMessage(i);
+
+  if (i < 4) {
+    // If i is less than 4, schedule the next call
+    timeoutID = setTimeout(doIncrement, 50);
+  }
+}
+
+doIncrement();
+


### PR DESCRIPTION
8313177: Web Workers timeout with Webkit 616.1
Reviewed-by: kcr, hmeda

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313177](https://bugs.openjdk.org/browse/JDK-8313177): Web Workers timeout with Webkit 616.1 (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/141/head:pull/141` \
`$ git checkout pull/141`

Update a local copy of the PR: \
`$ git checkout pull/141` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 141`

View PR using the GUI difftool: \
`$ git pr show -t 141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/141.diff">https://git.openjdk.org/jfx17u/pull/141.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/141#issuecomment-1703107778)