### PR TITLE
8289751: Multiple unit test failures after JDK-8251483

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import javafx.beans.property.SimpleStringProperty;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.sun.javafx.tk.Toolkit;
@@ -366,6 +367,7 @@ public class TableCellTest {
      * The item of the {@link TableRow} should not be null, when the {@link TableCell} is not empty.
      * See also: JDK-8251483
      */
+    @Ignore("Fails currently but will be enabled again in JDK-8289357")
     @Test
     public void testRowItemIsNotNullForNonEmptyCell() {
         TableColumn<String, String> tableColumn = new TableColumn<>();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -699,6 +699,7 @@ public class TreeTableCellTest {
      * The item of the {@link TreeTableRow} should not be null, when the {@link TreeTableCell} is not empty.
      * See also: JDK-8251483
      */
+    @Ignore("Fails currently but will be enabled again in JDK-8289357")
     @Test
     public void testRowItemIsNotNullForNonEmptyCell() {
         TreeTableColumn<String, String> treeTableColumn = new TreeTableColumn<>();


### PR DESCRIPTION
Clean backport of 8289751: Multiple unit test failures after JDK-8251483
Reviewed-by: kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289751](https://bugs.openjdk.org/browse/JDK-8289751): Multiple unit test failures after JDK-8251483 (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/153.diff">https://git.openjdk.org/jfx17u/pull/153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/153#issuecomment-1707256341)