### PR TITLE
8303680: Virtual Flow freezes after calling scrollTo and scrollPixels in succession

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1715,7 +1715,6 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
         // Finally, update the scroll bars
         updateScrollBarsAndCells(false);
-        lastPosition = getPosition();
 
         // notify
         return answer;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -2429,4 +2429,46 @@ public class ListViewTest {
 
     }
 
+    @Test
+    public void fixListViewCrash_JDK_8303680() {
+        final ListView<String> listView = new ListView<>();
+
+        // add 100 entries
+        listView.setPrefSize(200, 200);
+        for (int i = 0; i < 100; i++) {
+            listView.getItems().add("Item " + i);
+        }
+        StageLoader sl = new StageLoader(new VBox(listView, new Button()));
+
+        // pulse
+        Toolkit.getToolkit().firePulse();
+
+        // get virtual flow
+        VirtualFlow vf = VirtualFlowTestUtils.getVirtualFlow(listView);
+
+        // scroll to 50 and scroll 1 pixel
+        vf.scrollTo(50);
+        vf.scrollPixels(1);
+
+        // another pulse
+        Toolkit.getToolkit().firePulse();
+
+        // scroll to cell
+        IndexedCell<Integer> cell = vf.getCell(50);//VirtualFlowTestUtils.getCell(listView, 70);
+
+        // shouldn't be null
+        assertNotNull(cell);
+
+        // should be visible
+        assertTrue("Cell should be visible", cell.isVisible());
+
+        // should have parent
+        assertNotNull("Cell should have parent", cell.getParent());
+
+        // Note:
+        // We don't check for the position of the cell, because it's currently don't work properly.
+        // But we wan't to ensure, that the VirtualFlow "Doesn't crash" - which was the case before.
+
+    }
+
 }


### PR DESCRIPTION
Clean backport of 8303680: Virtual Flow freezes after calling scrollTo and scrollPixels in succession
Reviewed-by: angorya, jvos

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303680](https://bugs.openjdk.org/browse/JDK-8303680): Virtual Flow freezes after calling scrollTo and scrollPixels in succession (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/156/head:pull/156` \
`$ git checkout pull/156`

Update a local copy of the PR: \
`$ git checkout pull/156` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 156`

View PR using the GUI difftool: \
`$ git pr show -t 156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/156.diff">https://git.openjdk.org/jfx17u/pull/156.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/156#issuecomment-1707891677)