### PR TITLE
8306447: Adding an element to a long existing list may cause the first visible element to jump

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -98,7 +98,7 @@ public class VirtualFlowTest {
 
             @Override
             protected double computePrefWidth(double height) {
-                return flow.isVertical() ? (c.getIndex() == 29 ? 200 : 100) : (c.getIndex() == 29 ? 100 : 25);
+                return flow.isVertical() ? (getIndex() == 29 ? 200 : 100) : (getIndex() == 29 ? 100 : 25);
             }
 
             @Override
@@ -113,7 +113,7 @@ public class VirtualFlowTest {
 
             @Override
             protected double computePrefHeight(double width) {
-                return flow.isVertical() ? (c.getIndex() == 29 ? 100 : 25) : (c.getIndex() == 29 ? 200 : 100);
+                return flow.isVertical() ? (getIndex() == 29 ? 100 : 25) : (getIndex() == 29 ? 200 : 100);
             }
         });
         flow.setCellCount(100);
@@ -1222,6 +1222,38 @@ public class VirtualFlowTest {
             assertEquals("Wrong first cell position after inserting " + i + " cells", -10d, cellPosition, 0d);
         }
     }
+
+    @Test
+    // see JDK-8306447
+    public void testPositionCellRemainsConstantWithManyItems() {
+        flow.setVertical(true);
+        flow.setCellCount(100);
+        flow.resize(300, 300);
+        // scroll up and down, to populate the size cache
+        for (int i = 0; i < 20; i++) {
+            flow.scrollPixels(1);
+            pulse();
+            flow.scrollPixels(-1);
+            pulse();
+        }
+        flow.scrollPixels(911);
+        pulse();
+
+        IndexedCell vc = flow.getCell(33);
+        double cellPosition = flow.getCellPosition(vc);
+        // cell 33 should be at (32 x 25 + 1 x 100) - 911 = -11
+        assertEquals("Wrong first cell position", -11d, cellPosition, 0d);
+
+        for (int i = 1; i < 10; i++) {
+            flow.setCellCount(100 + i);
+            pulse();
+            vc = flow.getCell(33);
+            cellPosition = flow.getCellPosition(vc);
+            assertEquals("First cell position changed after adding " + i + " cells on large irregular list", -11d, cellPosition, 0d);
+        }
+    }
+
+
 
     @Test
     // see JDK-8252811


### PR DESCRIPTION
Clean backport of 8306447: Adding an element to a long existing list may cause the first visible element to jump
Reviewed-by: angorya, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306447](https://bugs.openjdk.org/browse/JDK-8306447): Adding an element to a long existing list may cause the first visible element to jump (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/157/head:pull/157` \
`$ git checkout pull/157`

Update a local copy of the PR: \
`$ git checkout pull/157` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 157`

View PR using the GUI difftool: \
`$ git pr show -t 157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/157.diff">https://git.openjdk.org/jfx17u/pull/157.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/157#issuecomment-1707941268)