### PR TITLE
8293836: Rendering performance degradation at bottom of TableView with many rows

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1998,8 +1998,6 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             double height = Math.max(getMaxPrefBreadth(), getViewportBreadth());
             cell.resize(fixedCellSizeEnabled ? getFixedCellSize() : Utils.boundedSize(cell.prefWidth(height), cell.minWidth(height), cell.maxWidth(height)), height);
         }
-        // when a cell is resized, our estimate needs to be updated.
-        recalculateAndImproveEstimatedSize(0);
     }
 
     /**
@@ -3102,19 +3100,20 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
      */
     void updateCellSize(T cell) {
         int cellIndex = cell.getIndex();
-        int currentIndex = computeCurrentIndex();
-        double oldOffset = computeViewportOffset(getPosition());
-
 
         if (itemSizeCache.size() > cellIndex) {
             Double oldSize = itemSizeCache.get(cellIndex);
             double newSize = isVertical() ? cell.getLayoutBounds().getHeight() : cell.getLayoutBounds().getWidth();
             itemSizeCache.set(cellIndex, newSize);
-            if ((cellIndex == currentIndex) && (oldSize != null) && (oldOffset != 0)) {
-                oldOffset = oldOffset + newSize - oldSize;
+            if ((oldSize != null) && !oldSize.equals(newSize)) {
+                int currentIndex = computeCurrentIndex();
+                double oldOffset = computeViewportOffset(getPosition());
+                if ((cellIndex == currentIndex) && (oldOffset != 0)) {
+                    oldOffset = oldOffset + newSize - oldSize;
+                }
+                recalculateAndImproveEstimatedSize(0, currentIndex, oldOffset);
             }
         }
-        recalculateAndImproveEstimatedSize(0, currentIndex, oldOffset);
     }
 
     /**


### PR DESCRIPTION
Clean backport of 8293836: Rendering performance degradation at bottom of TableView with many rows

Reviewed-by: angorya, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293836](https://bugs.openjdk.org/browse/JDK-8293836): Rendering performance degradation at bottom of TableView with many rows (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/158.diff">https://git.openjdk.org/jfx17u/pull/158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/158#issuecomment-1708024739)