### PR TITLE
8310638: Filtering a TableView with a large number of items freezes the UI

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -858,6 +858,9 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             int oldIndex = computeCurrentIndex(oldCount);
             double oldOffset = computeViewportOffset(getPosition(), oldCount);
             int cellCount = get();
+            if (oldIndex > cellCount) {
+                oldIndex = cellCount;
+            }
             resetSizeEstimates();
             recalculateAndImproveEstimatedSize(DEFAULT_IMPROVEMENT, oldIndex, oldOffset);
 
@@ -2988,7 +2991,11 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         return baseOffset;
     }
 
-    private int computeCurrentIndex() {
+    /**
+     * Compute the index of the first visible cell
+     * This has package access ONLY FOR TESTING.
+     */
+    int computeCurrentIndex() {
         return computeCurrentIndex(getCellCount());
     }
 

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
@@ -78,6 +78,10 @@ public class VirtualFlowShim<T extends IndexedCell> extends VirtualFlow<T> {
         return super.getVbar();
     }
 
+    public int shim_computeCurrentIndex() {
+        return super.computeCurrentIndex();
+    }
+
     public ClippedContainer get_clipView() {
         return super.clipView;
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -71,6 +71,7 @@ public class VirtualFlowTest {
     private CellStub a;
     private CellStub b;
     private CellStub c;
+    private int prefSizeCounter;
 
     // The VirtualFlow we are going to test. By default, there are 100 cells
     // and each cell is 100 wide and 25 tall, except for the 30th cell, which
@@ -79,7 +80,8 @@ public class VirtualFlowTest {
 
 
     @Before public void setUp() {
-        list = new ArrayLinkedListShim<CellStub>();
+        prefSizeCounter = 0;
+        list = new ArrayLinkedListShim<>();
         a = new CellStub(flow, "A");
         b = new CellStub(flow, "B");
         c = new CellStub(flow, "C");
@@ -100,6 +102,7 @@ public class VirtualFlowTest {
 
             @Override
             protected double computePrefWidth(double height) {
+                prefSizeCounter++;
                 return flow.isVertical() ? (getIndex() == 29 ? 200 : 100) : (getIndex() == 29 ? 100 : 25);
             }
 
@@ -115,6 +118,7 @@ public class VirtualFlowTest {
 
             @Override
             protected double computePrefHeight(double width) {
+                prefSizeCounter++;
                 return flow.isVertical() ? (getIndex() == 29 ? 100 : 25) : (getIndex() == 29 ? 200 : 100);
             }
         });
@@ -1713,6 +1717,38 @@ assertEquals(0, firstCell.getIndex());
         // Trigger layout and see if the computeXXX method are called above.
         pulse();
         pulse();
+    }
+
+    @Test
+    public void testLowerCellCount() {
+        flow.setCellCount(10000);
+        int idx = flow.shim_computeCurrentIndex();
+        assertEquals(0, idx);
+
+        assertTrue(prefSizeCounter < 500);
+        int cntr = prefSizeCounter;
+        flow.scrollTo(9999);
+        pulse();
+        idx = flow.shim_computeCurrentIndex();
+        assertTrue(idx < 10000);
+        int newCounter = prefSizeCounter - cntr;
+        assertTrue(newCounter < 100);
+        cntr = prefSizeCounter;
+
+        flow.setCellCount(5000);
+        idx = flow.shim_computeCurrentIndex();
+        assertTrue(idx < 5000);
+        newCounter = prefSizeCounter - cntr;
+        assertTrue(newCounter < 100);
+        cntr = prefSizeCounter;
+
+        pulse();
+        idx = flow.shim_computeCurrentIndex();
+        assertTrue(idx < 5000);
+        newCounter = prefSizeCounter - cntr;
+
+        assertTrue(newCounter < 100);
+
     }
 }
 


### PR DESCRIPTION
Almost clean backport of 8310638: Filtering a TableView with a large number of items freezes the UI
Reviewed-by: kcr, angorya

There was a small conflict in VirtualFlowTest due to JDK-8297414:
```
-        list = new ArrayLinkedListShim<CellStub>();
+        list = new ArrayLinkedListShim<>();
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310638](https://bugs.openjdk.org/browse/JDK-8310638): Filtering a TableView with a large number of items freezes the UI (**Bug** - P2)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/160/head:pull/160` \
`$ git checkout pull/160`

Update a local copy of the PR: \
`$ git checkout pull/160` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 160`

View PR using the GUI difftool: \
`$ git pr show -t 160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/160.diff">https://git.openjdk.org/jfx17u/pull/160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/160#issuecomment-1708135857)