### PR TITLE
8138842: TableViewSelectionModel.selectIndices does not select index 0

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -2564,7 +2564,7 @@ public class TableView<S> extends Control {
         }
 
         @Override public void selectIndices(int row, int... rows) {
-            if (rows == null) {
+            if (rows == null || rows.length == 0) {
                 select(row);
                 return;
             }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -2925,7 +2925,7 @@ public class TreeTableView<S> extends Control {
         }
 
         @Override public void selectIndices(int row, int... rows) {
-            if (rows == null) {
+            if (rows == null || rows.length == 0) {
                 select(row);
                 return;
             }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -5941,29 +5941,6 @@ public class TableViewTest {
         assertTrue(arrowMaxX < cornerMinX);
     }
 
-    @Test
-    public void testQueryAccessibleAttributeSelectedItemsWithNullSelectionModel() {
-        table.getItems().addAll("1", "2");
-        table.setSelectionModel(null);
-        stageLoader = new StageLoader(table);
-
-        Object result = table.queryAccessibleAttribute(AccessibleAttribute.SELECTED_ITEMS);
-        // Should be an empty observable array list
-        assertEquals(FXCollections.observableArrayList(), result);
-    }
-
-    @Test
-    public void testQueryAccessibleAttributeFocusItemWithNullFocusModel() {
-        table.getItems().addAll("1", "2");
-        table.setFocusModel(null);
-
-        stageLoader = new StageLoader(table);
-
-        Object result = table.queryAccessibleAttribute(AccessibleAttribute.FOCUS_ITEM);
-
-        assertNull(result);
-    }
-
     // See JDK-8089280
     @Test
     public void testSuppressHorizontalScrollBar() {
@@ -5990,5 +5967,44 @@ public class TableViewTest {
 
         hbar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
         assertFalse(hbar.isVisible()); // used to fail here
+    }
+
+
+    @Test
+    public void testQueryAccessibleAttributeSelectedItemsWithNullSelectionModel() {
+        table.getItems().addAll("1", "2");
+        table.setSelectionModel(null);
+        stageLoader = new StageLoader(table);
+
+        Object result = table.queryAccessibleAttribute(AccessibleAttribute.SELECTED_ITEMS);
+        // Should be an empty observable array list
+        assertEquals(FXCollections.observableArrayList(), result);
+    }
+
+    @Test
+    public void testQueryAccessibleAttributeFocusItemWithNullFocusModel() {
+        table.getItems().addAll("1", "2");
+        table.setFocusModel(null);
+
+        stageLoader = new StageLoader(table);
+
+        Object result = table.queryAccessibleAttribute(AccessibleAttribute.FOCUS_ITEM);
+
+        assertNull(result);
+    }
+
+    // See JDK-8138842
+    @Test
+    public void testFirstRowSelectionWithEmptyArrayAsParameter() {
+        table.getItems().addAll("1", "2", "3");
+
+        table.getSelectionModel().selectIndices(0, new int[0]);
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+
+        table.getSelectionModel().selectIndices(1, new int[0]);
+        assertEquals(1, table.getSelectionModel().getSelectedIndex());
+
+        table.getSelectionModel().selectIndices(1, new int[]{1, 2});
+        assertEquals(2, table.getSelectionModel().getSelectedIndex());
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -7177,4 +7177,24 @@ public class TreeTableViewTest {
         hbar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
         assertFalse(hbar.isVisible()); // used to fail here
     }
+
+    // See JDK-8138842
+    @Test
+    public void testFirstRowSelectionWithEmptyArrayAsParameter() {
+        treeTableView.setRoot(new TreeItem("Root"));
+        treeTableView.getRoot().setExpanded(true);
+        for (int i = 0; i < 4; i++) {
+            TreeItem parent = new TreeItem("item - " + i);
+            treeTableView.getRoot().getChildren().add(parent);
+        }
+
+        treeTableView.getSelectionModel().selectIndices(0, new int[0]);
+        assertEquals(0, treeTableView.getSelectionModel().getSelectedIndex());
+
+        treeTableView.getSelectionModel().selectIndices(1, new int[0]);
+        assertEquals(1, treeTableView.getSelectionModel().getSelectedIndex());
+
+        treeTableView.getSelectionModel().selectIndices(1, new int[]{1, 2});
+        assertEquals(2, treeTableView.getSelectionModel().getSelectedIndex());
+    }
 }


### PR DESCRIPTION
Almost clean backport of 8138842: TableViewSelectionModel.selectIndices does not select index 0
Reviewed-by: angorya, aghaisas

There were conflicts with the insertion point of the two tests TableViewTest and TreeTableViewTest.

In the case of TableViewTest: also two tests that already exist were added at the end (as this is how they are upstream), so the conflict was resolved by removing the two original tests, so the order of tests remains the same as upstream.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8138842](https://bugs.openjdk.org/browse/JDK-8138842): TableViewSelectionModel.selectIndices does not select index 0 (**Bug** - P4)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/161.diff">https://git.openjdk.org/jfx17u/pull/161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/161#issuecomment-1708426060)