### PR TITLE
8311127: Regression: The fix for TableView and TreeTableView menu button affects all table column headers

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -369,7 +369,7 @@ public class TableColumnHeader extends Region {
             isSizeDirty = false;
         }
 
-        double cornerRegionPadding = tableHeaderRow == null ? 0.0 : tableHeaderRow.cornerPadding.get();
+        double cornerRegionPadding = tableHeaderRow == null || !isLastVisibleColumn ? 0.0 : tableHeaderRow.cornerPadding.get();
         double sortWidth = 0;
         double w = snapSizeX(getWidth()) - (snappedLeftInset() + snappedRightInset()) - cornerRegionPadding;
         double h = getHeight() - (snappedTopInset() + snappedBottomInset());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -5941,6 +5941,53 @@ public class TableViewTest {
         assertTrue(arrowMaxX < cornerMinX);
     }
 
+    // See JDK-8311127
+    @Test
+    public void testTableMenuButtonOnlyChangesLastVisibleColumnHeader() {
+        TableView<String> table = new TableView<>();
+        table.setTableMenuButtonVisible(true);
+        for (int i = 0; i < 10; i++) {
+            final TableColumn<String, String> column = new TableColumn<>("Header");
+            column.setCellValueFactory(value -> new SimpleStringProperty(value.getValue()));
+            table.getColumns().add(column);
+        }
+        for (int i = 0; i < 10; i++) {
+            table.getItems().add(Integer.toString(i));
+        }
+
+        stageLoader = new StageLoader(new Scene(table, 300, 300));
+
+        List<Double> labelWidths = table.getColumns().stream()
+                .map(column -> VirtualFlowTestUtils.getTableColumnHeader(table, column))
+                .map(columnHeader -> columnHeader.getChildrenUnmodifiable().get(0))
+                .map(node -> node.getLayoutBounds().getWidth())
+                .toList();
+
+        // Verify that the column header width for all columns is the same:
+        for (int i = 1; i < 10; i++) {
+            assertEquals(labelWidths.get(i), labelWidths.get(0));
+        }
+
+        // scroll to last column and sort
+        table.scrollToColumnIndex(9);
+        TableColumn<String, ?> lastColumn = table.getColumns().get(9);
+        lastColumn.setSortType(DESCENDING);
+        table.getSortOrder().setAll(lastColumn);
+        Toolkit.getToolkit().firePulse();
+
+        List<Double> newLabelWidths = table.getColumns().stream()
+                .map(column -> VirtualFlowTestUtils.getTableColumnHeader(table, column))
+                .map(columnHeader -> columnHeader.getChildrenUnmodifiable().get(0))
+                .map(node -> node.getLayoutBounds().getWidth())
+                .toList();
+        // Verify that the column header width didn't change for the first 9 columns:
+        for (int i = 0; i < 9; i++) {
+            assertEquals(labelWidths.get(i), newLabelWidths.get(i));
+        }
+        // and did change for the last one:
+        assertTrue(labelWidths.get(9) > newLabelWidths.get(9));
+    }
+
     // See JDK-8089280
     @Test
     public void testSuppressHorizontalScrollBar() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -7093,6 +7093,89 @@ public class TreeTableViewTest {
         assertTrue(arrowMaxX < cornerMinX);
     }
 
+    // See JDK-8311127
+    @Test
+    public void testTreeTableMenuButtonOnlyChangesLastVisibleColumnHeader() {
+        TreeTableView<String> table = new TreeTableView<>();
+        table.setTableMenuButtonVisible(true);
+        for (int i = 0; i < 10; i++) {
+            TreeTableColumn<String, String> column = new TreeTableColumn<>(i + "          ");
+            column.setCellValueFactory(value -> new SimpleStringProperty(value.getValue().getValue()));
+            table.getColumns().add(column);
+        }
+
+        TreeItem<String> root = new TreeItem<>();
+        root.setExpanded(true);
+        for (int i = 0; i < 10; i++) {
+            root.getChildren().add(new TreeItem<>(Integer.toString(i)));
+        }
+        table.setRoot(root);
+        table.setShowRoot(false);
+
+        stageLoader = new StageLoader(new Scene(table, 300, 300));
+
+        List<Double> labelWidths = table.getColumns().stream()
+                .map(column -> VirtualFlowTestUtils.getTableColumnHeader(table, column))
+                .map(columnHeader -> columnHeader.getChildrenUnmodifiable().get(0))
+                .map(node -> node.getLayoutBounds().getWidth())
+                .toList();
+
+        // Verify that the column header width for all columns is the same:
+        for (int i = 1; i < 10; i++) {
+            assertEquals(labelWidths.get(i), labelWidths.get(0));
+        }
+
+        // scroll to last column and sort
+        table.scrollToColumnIndex(9);
+        TreeTableColumn<String, ?> lastColumn = table.getColumns().get(9);
+        lastColumn.setSortType(TreeTableColumn.SortType.DESCENDING);
+        table.getSortOrder().setAll(lastColumn);
+        Toolkit.getToolkit().firePulse();
+
+        List<Double> newLabelWidths = table.getColumns().stream()
+                .map(column -> VirtualFlowTestUtils.getTableColumnHeader(table, column))
+                .map(columnHeader -> columnHeader.getChildrenUnmodifiable().get(0))
+                .map(node -> node.getLayoutBounds().getWidth())
+                .toList();
+        // Verify that the column header width didn't change for the first 9 columns:
+        for (int i = 0; i < 9; i++) {
+            assertEquals(labelWidths.get(i), newLabelWidths.get(i));
+        }
+        // and did change for the last one:
+        assertTrue(labelWidths.get(9) > newLabelWidths.get(9));
+    }
+
+    // See JDK-8089280
+    @Test
+    public void testSuppressHorizontalScrollBar() {
+        TreeItem<String> root = new TreeItem<>();
+        root.setExpanded(true);
+        for (int i = 0; i < 10; i++) {
+            root.getChildren().add(new TreeItem<>(""));
+        }
+
+        TreeTableView<String> table = new TreeTableView<>();
+        for (int i = 0; i < 10; i++) {
+            TreeTableColumn<String, String> c = new TreeTableColumn<>("C" + i);
+            c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue().getValue()));
+            table.getColumns().add(c);
+        }
+        table.setRoot(root);
+        table.setShowRoot(false);
+
+        stageLoader = new StageLoader(new Scene(table, 50, 50));
+
+        ScrollBar hbar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
+        assertTrue(hbar.isVisible());
+
+        table.setColumnResizePolicy(TreeTableView.CONSTRAINED_RESIZE_POLICY);
+
+        Toolkit.getToolkit().firePulse();
+
+        hbar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
+        assertFalse(hbar.isVisible()); // used to fail here
+    }
+
     @Test
     public void testQueryAccessibleAttributeSelectedItemsWithNullSelectionModel() {
         treeTableView.setSelectionModel(null);
@@ -7145,37 +7228,6 @@ public class TreeTableViewTest {
 
         Object result = treeTableView.queryAccessibleAttribute(AccessibleAttribute.FOCUS_ITEM);
         assertNull(result);
-    }
-
-    // See JDK-8089280
-    @Test
-    public void testSuppressHorizontalScrollBar() {
-        TreeItem<String> root = new TreeItem<>();
-        root.setExpanded(true);
-        for (int i = 0; i < 10; i++) {
-            root.getChildren().add(new TreeItem<>(""));
-        }
-
-        TreeTableView<String> table = new TreeTableView<>();
-        for (int i = 0; i < 10; i++) {
-            TreeTableColumn<String, String> c = new TreeTableColumn<>("C" + i);
-            c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue().getValue()));
-            table.getColumns().add(c);
-        }
-        table.setRoot(root);
-        table.setShowRoot(false);
-
-        stageLoader = new StageLoader(new Scene(table, 50, 50));
-
-        ScrollBar hbar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
-        assertTrue(hbar.isVisible());
-
-        table.setColumnResizePolicy(TreeTableView.CONSTRAINED_RESIZE_POLICY);
-
-        Toolkit.getToolkit().firePulse();
-
-        hbar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
-        assertFalse(hbar.isVisible()); // used to fail here
     }
 
     // See JDK-8138842


### PR DESCRIPTION
Almost clean backport of 8311127: Regression: The fix for TableView and TreeTableView menu button affects all table column headers
Reviewed-by: angorya

There was a conflict with the insertion point of the test in TreeTableViewTest, that was solved by swapping the order of tests to match up with upstream.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311127](https://bugs.openjdk.org/browse/JDK-8311127): Regression: The fix for TableView and TreeTableView menu button affects all table column headers (**Bug** - P3)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/162/head:pull/162` \
`$ git checkout pull/162`

Update a local copy of the PR: \
`$ git checkout pull/162` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 162`

View PR using the GUI difftool: \
`$ git pr show -t 162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/162.diff">https://git.openjdk.org/jfx17u/pull/162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/162#issuecomment-1708484752)