### PR TITLE
Backport 0371b349c929a0f8e71d8f2a01b1e565bb885e6c

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -862,6 +862,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
                 oldIndex = cellCount;
             }
             resetSizeEstimates();
+            getOrCreateCellSize(oldIndex);
             recalculateAndImproveEstimatedSize(DEFAULT_IMPROVEMENT, oldIndex, oldOffset);
 
             boolean countChanged = oldCount != cellCount;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1750,6 +1750,24 @@ assertEquals(0, firstCell.getIndex());
         assertTrue(newCounter < 100);
 
     }
+
+    @Test
+    public void testAddCellWithBigCurrentOne() {
+        int idx = flow.shim_computeCurrentIndex();
+        assertEquals(0, idx);
+        for (int i = 0; i < 20; i++) {
+            flow.scrollPixels(40);
+            pulse();
+        }
+        pulse();
+        idx = flow.shim_computeCurrentIndex();
+        assertEquals(29, idx);
+        flow.setCellCount(101);
+        pulse();
+        idx = flow.shim_computeCurrentIndex();
+        assertEquals(29, idx);
+    }
+
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {


### PR DESCRIPTION
Clean backport of 8311185: VirtualFlow jump when cellcount changes
Reviewed-by: angorya, kcr