### PR TITLE
8319066: Application window not always activated in macOS 14 Sonoma

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -54,6 +54,7 @@ static jobject nestedLoopReturnValue = NULL;
 static BOOL isFullScreenExitingLoop = NO;
 static NSMutableDictionary * keyCodeForCharMap = nil;
 static BOOL isEmbedded = NO;
+static BOOL requiresActivation = NO;
 static BOOL triggerReactivation = NO;
 static BOOL disableSyncRendering = NO;
 static BOOL firstActivation = YES;
@@ -239,6 +240,15 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     }
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);
+
+     if (!NSApp.isActive && requiresActivation) {
+        // As of macOS 14, application gets to the foreground,
+        // but it doesn't get activated, so this is needed:
+        LOG("-> need to active application");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [NSApp activate];
+        });
+    }
 }
 
 - (void)applicationWillBecomeActive:(NSNotification *)aNotification
@@ -539,6 +549,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
                 // anyway) as of macOS 14
                 if (@available(macOS 14.0, *)) {
                     triggerReactivation = NO;
+                    requiresActivation = YES;
                 }
 
                 // move process from background only to full on app with visible Dock icon


### PR DESCRIPTION
Clean backport of 8319066: Application window not always activated in macOS 14 Sonoma
Reviewed-by: kcr, arapte

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319066](https://bugs.openjdk.org/browse/JDK-8319066): Application window not always activated in macOS 14 Sonoma (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/166.diff">https://git.openjdk.org/jfx17u/pull/166.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/166#issuecomment-1787884001)