### PR TITLE
8299968: Second call to Stage.setScene() create sizing issue with uiScale > 1.0

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
@@ -348,6 +348,7 @@ public abstract class Window {
     }
 
     protected abstract boolean _setView(long ptr, View view);
+    protected abstract void _updateViewSize(long ptr);
     public void setView(final View view) {
         Application.checkEventThread();
         checkNotClosed();
@@ -369,6 +370,10 @@ public abstract class Window {
         if (view != null && _setView(this.ptr, view)) {
             this.view = view;
             this.view.setWindow(this);
+            // View size update (especially notifyResize event) has to happen
+            // after we call view.setWindow(this); otherwise with UI scaling different than
+            // 100% some platforms might display scenes wrong after Window was shown.
+            _updateViewSize(this.ptr);
             if (this.isDecorated == false) {
                 this.helper = new UndecoratedMoveResizeHelper();
             }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
@@ -46,6 +46,10 @@ class GtkWindow extends Window {
     @Override
     protected native boolean _setView(long ptr, View view);
 
+    // empty - not needed by this implementation
+    @Override
+    protected void _updateViewSize(long ptr) {}
+
     @Override
     protected boolean _setMenubar(long ptr, long menubarPtr) {
         //TODO is it needed?

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosWindow.java
@@ -67,6 +67,10 @@ final class IosWindow extends Window {
     @Override native protected boolean _grabFocus(long ptr);
     @Override native protected void _ungrabFocus(long ptr);
 
+    // empty - not needed by this implementation
+    @Override
+    protected void _updateViewSize(long ptr) {}
+
     //No cursor on iOS. API compatibility call.
     @Override
     protected void _setCursor(long ptr, Cursor cursor) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
@@ -55,6 +55,8 @@ final class MacWindow extends Window {
     @Override native protected boolean _setMenubar(long ptr, long menubarPtr);
     @Override native protected boolean _minimize(long ptr, boolean minimize);
     @Override native protected boolean _maximize(long ptr, boolean maximize, boolean wasMaximized);
+    // empty - not needed by this implementation
+    @Override protected void _updateViewSize(long ptr) {}
     @Override protected void _setBounds(long ptr,
                                         int x, int y, boolean xSet, boolean ySet,
                                         int w, int h, int cw, int ch,

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
@@ -179,6 +179,10 @@ final class MonocleWindow extends Window {
         return result;
     }
 
+    // empty - not needed by this implementation
+    @Override
+    protected void _updateViewSize(long ptr) {}
+
     /**
      * Returns the handle used to create a rendering context in Prism
      */

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
@@ -249,6 +249,7 @@ class WinWindow extends Window {
     @Override native protected long _createWindow(long ownerPtr, long screenPtr, int mask);
     @Override native protected boolean _close(long ptr);
     @Override native protected boolean _setView(long ptr, View view);
+    @Override native protected void _updateViewSize(long ptr);
     @Override native protected boolean _setMenubar(long ptr, long menubarPtr);
     @Override native protected boolean _minimize(long ptr, boolean minimize);
     @Override native protected boolean _maximize(long ptr, boolean maximize, boolean wasMaximized);

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -1297,10 +1297,6 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_win_WinWindow__1setView
         }
         pWindow->ResetMouseTracking(hWnd);
         pWindow->SetGlassView(view);
-        // The condition below may be restricted to WS_POPUP windows
-        if (::IsWindowVisible(hWnd)) {
-            pWindow->NotifyViewSize(hWnd);
-        }
     }
     GlassView * view;
     LEAVE_MAIN_THREAD_WITH_hWnd;
@@ -1309,6 +1305,28 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_win_WinWindow__1setView
 
     PERFORM();
     return JNI_TRUE;
+}
+
+/**
+ * Class:     com_sun_glass_ui_win_WinWindow
+ * Method:    _updateViewSize
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinWindow__1updateViewSize
+    (JNIEnv * env, jobject jThis, jlong ptr)
+{
+    ENTER_MAIN_THREAD()
+    {
+        GlassWindow *pWindow = GlassWindow::FromHandle(hWnd);
+
+        // The condition below may be restricted to WS_POPUP windows
+        if (::IsWindowVisible(hWnd)) {
+            pWindow->NotifyViewSize(hWnd);
+        }
+    }
+    LEAVE_MAIN_THREAD_WITH_hWnd;
+
+    PERFORM();
 }
 
 /*

--- a/tests/system/src/test/java/test/robot/javafx/stage/SetSceneScalingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/SetSceneScalingTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.robot.javafx.stage;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javafx.application.Platform;
+import javafx.event.ActionEvent;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.VBox;
+import javafx.scene.robot.Robot;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import javafx.stage.WindowEvent;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import test.util.Util;
+
+public class SetSceneScalingTest {
+    static CountDownLatch startupLatch = new CountDownLatch(1);
+    static Robot robot;
+
+    TestApp app;
+
+
+    public abstract class TestApp {
+        protected CountDownLatch shownLatch = new CountDownLatch(1);
+        protected CountDownLatch buttonLatch;
+        protected Stage stage;
+        protected Button button;
+
+        private final int WIDTH = 400;
+        private final int HEIGHT = 400;
+
+        protected void testButtonClick() {
+            robot.mouseMove((int)(stage.getX() + stage.getScene().getX()) + (WIDTH / 2),
+                            (int)(stage.getY() + stage.getScene().getY()) + (HEIGHT / 2));
+            robot.mousePress(MouseButton.PRIMARY);
+            robot.mouseRelease(MouseButton.PRIMARY);
+        }
+
+        protected Scene createTestScene() {
+            buttonLatch = new CountDownLatch(1);
+
+            button = new Button("I should be centered");
+            button.setOnAction((ActionEvent e) -> buttonLatch.countDown());
+
+            VBox box = new VBox(button);
+            box.setAlignment(Pos.CENTER);
+            return new Scene(box);
+        }
+
+        protected abstract void test() throws Exception;
+        protected abstract void sceneShowSetup();
+
+        public void runTest() throws Exception {
+            start();
+
+            Assert.assertNotNull(stage);
+            Assert.assertNotNull(button);
+
+            test();
+        }
+
+        public void start() {
+            Util.runAndWait(() -> {
+                stage = new Stage(StageStyle.UNDECORATED);
+                stage.setOnShown(e -> Platform.runLater(() -> shownLatch.countDown()));
+                stage.setWidth(WIDTH);
+                stage.setHeight(HEIGHT);
+                stage.setAlwaysOnTop(true);
+
+                sceneShowSetup();
+            });
+
+            Util.waitForLatch(shownLatch, 5, "Stage not shown");
+        }
+
+        public void hideStage() {
+            stage.hide();
+        }
+    }
+
+    public class TestSetSceneShowApp extends TestApp {
+        @Override
+        protected void test() throws Exception {
+            Platform.runLater(() -> testButtonClick());
+            Assert.assertTrue(buttonLatch.await(3, TimeUnit.SECONDS));
+        }
+
+        @Override
+        public void sceneShowSetup() {
+            stage.setScene(createTestScene());
+            stage.show();
+        }
+    }
+
+    public class TestShowSetSceneApp extends TestApp {
+        @Override
+        protected void test() throws Exception {
+            Platform.runLater(() -> testButtonClick());
+            Assert.assertTrue(buttonLatch.await(3, TimeUnit.SECONDS));
+        }
+
+        @Override
+        public void sceneShowSetup() {
+            stage.show();
+            stage.setScene(createTestScene());
+        }
+    }
+
+    public class TestSecondSetSceneApp extends TestApp {
+        @Override
+        protected void test() throws Exception {
+            // Test that everything is okay for start
+            Platform.runLater(() -> testButtonClick());
+            Assert.assertTrue(buttonLatch.await(3, TimeUnit.SECONDS));
+
+            // Recreate scene and set it
+            Util.runAndWait(() -> stage.setScene(createTestScene()));
+
+            // retest - if DPI scaling is mishandled the button should
+            // NOT be where it was (and thus, the test fails)
+            Platform.runLater(() -> testButtonClick());
+            Assert.assertTrue(buttonLatch.await(3, TimeUnit.SECONDS));
+        }
+
+        @Override
+        public void sceneShowSetup() {
+            stage.setScene(createTestScene());
+            stage.show();
+        }
+    }
+
+
+    @BeforeClass
+    public static void initFX() {
+        Platform.setImplicitExit(false);
+        Util.startup(startupLatch, startupLatch::countDown);
+
+        Util.runAndWait(() -> robot = new Robot());
+    }
+
+    @After
+    public void cleanupTest() {
+        if (app != null) {
+            Platform.runLater(() -> app.hideStage());
+        }
+    }
+
+    @AfterClass
+    public static void teardownFX() {
+        Util.shutdown();
+    }
+
+
+    @Test
+    public void testSetSceneAndShow() throws Exception {
+        app = new TestSetSceneShowApp();
+        app.runTest();
+    }
+
+    @Test
+    public void testShowAndSetScene() throws Exception {
+        app = new TestShowSetSceneApp();
+        app.runTest();
+    }
+
+    @Test
+    public void testSecondSetScene() throws Exception {
+        app = new TestSecondSetSceneApp();
+        app.runTest();
+    }
+}

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -37,16 +37,22 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import javafx.application.Application;
 import javafx.application.Platform;
-import junit.framework.AssertionFailedError;
+import javafx.stage.Stage;
+
 import org.junit.Assert;
+
+import junit.framework.AssertionFailedError;
 
 /**
  * Utility methods for life-cycle testing
  */
 public class Util {
-
-    // Test timeout value in milliseconds
+    /** Default startup timeout value in seconds */
+    public static final int STARTUP_TIMEOUT = 15;
+    /** Test timeout value in milliseconds */
     public static final int TIMEOUT = 10000;
 
     private static interface Future {
@@ -293,5 +299,101 @@ public class Util {
         }
 
         return cmd;
+    }
+
+    /**
+     * Launches an FX application, at the same time ensuring that it has been
+     * actually launched within {@link #STARTUP_TIMEOUT} (15 seconds).
+     * <p>
+     * The application being started must call {@link CountdownLatch#countDown()} once to signal
+     * its successful start (for example, by setting a handler for {@link javafx.stage.WindowEvent.WINDOW_SHOWN} event
+     * on its primary Stage).
+     *
+     * @param startupLatch - a latch used to communicate successful start of the application
+     * @param applicationClass - application to launch
+     * @param args - command line arguments
+     */
+    public static <T extends Application> void launch (
+            CountDownLatch startupLatch,
+            Class<T> applicationClass,
+            String... args) {
+        launch(startupLatch, STARTUP_TIMEOUT, applicationClass, args);
+    }
+
+    /**
+     * Launches an FX application, at the same time ensuring that it has been
+     * actually launched within the specified time.
+     * <p>
+     * The application being started must call {@link java.util.concurrent.CountdownLatch#countDown()} once to signal
+     * its successful start (for example, by setting a handler for {@link javafx.stage.WindowEvent.WINDOW_SHOWN} event
+     * on its primary Stage).
+     *
+     * @param startupLatch - a latch used to communicate successful start of the application
+     * @param timeoutSeconds - timeout in seconds after which the test fails
+     * @param applicationClass - application to launch
+     * @param args - command line arguments
+     */
+    public static <T extends Application> void launch (
+            CountDownLatch startupLatch,
+            int timeoutSeconds,
+            Class<T> applicationClass,
+            String... args) {
+
+        new Thread(() -> {
+            Application.launch(applicationClass, args);
+        }).start();
+
+        String msg = "Failed to launch FX application " + applicationClass + " within " + timeoutSeconds + " sec.";
+        try {
+            Assert.assertTrue(msg, startupLatch.await(timeoutSeconds, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Starts the JavaFX runtime, invoking the specified Runnable on the JavaFX application thread.
+     * This Runnable must call {@link java.util.concurrent.CountDownLatch#countDown()} once to signal
+     * its successful start, otherwise an exception will be thrown when no such signal is received
+     * within {@link #STARTUP_TIMEOUT} (15 seconds).
+     *
+     * @param startupLatch - a latch used to communicate successful start of the application
+     * @param r - code to invoke on the application thread.
+     */
+    public static void startup(CountDownLatch startupLatch, Runnable r) {
+        Platform.startup(r);
+        try {
+            String msg = "Timeout waiting for FX runtime to start";
+            Assert.assertTrue(msg, startupLatch.await(STARTUP_TIMEOUT, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * This synchronous method first hides all the specified stages (ignoring any
+     * null Stages) in the platform thread, then calls {@link Platform.exit()}.
+     */
+    public static void shutdown(Stage... stages) {
+        runAndWait(() -> {
+            for (Stage s : stages) {
+                if (s != null) {
+                    s.hide();
+                }
+            }
+            Platform.exit();
+        });
+    }
+
+    /**
+     * Calls CountDownLatch.await() with the specified timeout (in seconds).
+     * Throws an exception if await() returns false or the process gets interrupted.
+     */
+    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
+        try {
+            Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
     }
 }


### PR DESCRIPTION
Backport of 8299968: Second call to Stage.setScene() create sizing issue with uiScale > 1.0

Reviewed-by: kcr, arapte

The backport didn't pass the pre-submit tests: The added test in JDK-8299968 (`SetSceneScalingTest`) was using some methods from `/tests/system/src/test/java/test/util/Util.java` that weren't back ported yet.

Those methods were added in https://bugs.openjdk.org/browse/JDK-8206430, with a commit that modified 101 files. In order to avoid backporting all those files as well, this backport only cherry-picks the changes done to `Util.java` in such commit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299968](https://bugs.openjdk.org/browse/JDK-8299968): Second call to Stage.setScene() create sizing issue with uiScale &gt; 1.0 (**Bug** - P3)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/171/head:pull/171` \
`$ git checkout pull/171`

Update a local copy of the PR: \
`$ git checkout pull/171` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 171`

View PR using the GUI difftool: \
`$ git pr show -t 171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/171.diff">https://git.openjdk.org/jfx17u/pull/171.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/171#issuecomment-1840672353)