### PR TITLE
8260528: Clean glass-gtk sizing and positioning code

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
@@ -60,8 +60,6 @@ class GtkWindow extends Window {
 
     private native void maximizeImpl(long ptr, boolean maximize, boolean wasMaximized);
 
-    private native void setBoundsImpl(long ptr, int x, int y, boolean xSet, boolean ySet, int w, int h, int cw, int ch);
-
     private native void setVisibleImpl(long ptr, boolean visible);
 
     @Override
@@ -185,27 +183,10 @@ class GtkWindow extends Window {
         return _getNativeWindowImpl(super.getNativeWindow());
     }
 
-    private native void _setGravity(long ptr, float xGravity, float yGravity);
-
     @Override
-    protected void _setBounds(long ptr, int x, int y, boolean xSet, boolean ySet, int w, int h, int cw, int ch, float xGravity, float yGravity) {
-        _setGravity(ptr, xGravity, yGravity);
-        setBoundsImpl(ptr, x, y, xSet, ySet, w, h, cw, ch);
-
-        if ((w <= 0) && (cw > 0) || (h <= 0) && (ch > 0)) {
-            final int[] extarr = new int[4];
-            getFrameExtents(ptr, extarr);
-
-            // TODO: ((w <= 0) && (cw <= 0)) || ((h <= 0) && (ch <= 0))
-            notifyResize(WindowEvent.RESIZE,
-                         ((w <= 0) && (cw > 0)) ? cw + extarr[0] + extarr[1]
-                                                : w,
-                         ((h <= 0) && (ch > 0)) ? ch + extarr[2] + extarr[3]
-                                                : h);
-        }
-    }
-
-    private native void getFrameExtents(long ptr, int[] extarr);
+    protected native void _setBounds(long ptr, int x, int y, boolean xSet, boolean ySet,
+                                       int w, int h, int cw, int ch,
+                                       float xGravity, float yGravity);
 
     @Override
     protected void _requestInput(long ptr, String text, int type, double width, double height,

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -440,8 +440,9 @@ static void process_events(GdkEvent* event, gpointer data)
         try {
             switch (event->type) {
                 case GDK_PROPERTY_NOTIFY:
-                    ctx->process_property_notify(&event->property);
+                    // let gtk handle it first to prevent a glitch
                     gtk_main_do_event(event);
+                    ctx->process_property_notify(&event->property);
                     break;
                 case GDK_CONFIGURE:
                     ctx->process_configure(&event->configure);
@@ -492,7 +493,6 @@ static void process_events(GdkEvent* event, gpointer data)
                     process_dnd_target(ctx, &event->dnd);
                     break;
                 case GDK_MAP:
-                    ctx->process_map();
                     // fall-through
                 case GDK_UNMAP:
                 case GDK_CLIENT_EVENT:

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassWindow.cpp
@@ -172,17 +172,17 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow_maximizeImpl
 
 /*
  * Class:     com_sun_glass_ui_gtk_GtkWindow
- * Method:    setBoundsImpl
- * Signature: (JIIZZIIII)V
+ * Method:    _setBounds
+ * Signature: (JIIZZIIIIFF)V
  */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow_setBoundsImpl
-  (JNIEnv * env, jobject obj, jlong ptr, jint x, jint y, jboolean xSet, jboolean ySet, jint w, jint h, jint cw, jint ch)
-{
+JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1setBounds
+  (JNIEnv * env, jobject obj, jlong ptr, jint x, jint y, jboolean xSet, jboolean ySet,
+   jint w, jint h, jint cw, jint ch, jfloat xGravity, jfloat yGravity) {
     (void)env;
     (void)obj;
 
     WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
-    ctx->set_bounds(x, y, xSet, ySet, w, h, cw, ch);
+    ctx->set_bounds(x, y, xSet, ySet, w, h, cw, ch, xGravity, yGravity);
 }
 
 /*
@@ -428,7 +428,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1toFront
     (void)obj;
 
     WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
-    ctx->restack(true);
+    ctx->to_front();
 }
 
 /*
@@ -443,8 +443,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1toBack
     (void)obj;
 
     WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
-    ctx->restack(false);
-
+    ctx->to_back();
 }
 
 /*
@@ -539,6 +538,7 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_gtk_GtkWindow_isVisible
     WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
     return ctx->is_visible() ? JNI_TRUE : JNI_FALSE;
 }
+
 JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1getNativeWindowImpl
     (JNIEnv * env, jobject obj, jlong ptr)
 {
@@ -547,40 +547,6 @@ JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1getNativeWindowImp
 
     WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
     return GDK_WINDOW_XID(ctx->get_gdk_window());
-}
-/*
- * Class:     com_sun_glass_ui_gtk_GtkWindow
- * Method:    getFrameExtents
- * Signature: (J[I)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow_getFrameExtents
-    (JNIEnv * env, jobject obj, jlong ptr, jintArray extarr)
-{
-    (void)obj;
-
-    WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
-    WindowFrameExtents extents = ctx->get_frame_extents();
-
-    env->SetIntArrayRegion(extarr, 0, 1, &extents.left);
-    env->SetIntArrayRegion(extarr, 1, 1, &extents.right);
-    env->SetIntArrayRegion(extarr, 2, 1, &extents.top);
-    env->SetIntArrayRegion(extarr, 3, 1, &extents.bottom);
-}
-
-/*
- * Class:     com_sun_glass_ui_gtk_GtkWindow
- * Method:    _setGravity
- * Signature: (JFF)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1setGravity
-    (JNIEnv * env, jobject obj, jlong ptr, jfloat xGravity, jfloat yGravity)
-{
-    (void)env;
-    (void)obj;
-
-    WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
-    ctx->set_gravity(xGravity, yGravity);
-
 }
 
 } // extern "C"

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -101,12 +101,12 @@ void WindowContextBase::notify_state(jint glass_state) {
 }
 
 void WindowContextBase::process_state(GdkEventWindowState* event) {
-    if (event->changed_mask &
-            (GDK_WINDOW_STATE_ICONIFIED | GDK_WINDOW_STATE_MAXIMIZED)) {
+    if (event->changed_mask & (GDK_WINDOW_STATE_ICONIFIED | GDK_WINDOW_STATE_MAXIMIZED)) {
 
         if (event->changed_mask & GDK_WINDOW_STATE_ICONIFIED) {
             is_iconified = event->new_window_state & GDK_WINDOW_STATE_ICONIFIED;
         }
+
         if (event->changed_mask & GDK_WINDOW_STATE_MAXIMIZED) {
             is_maximized = event->new_window_state & GDK_WINDOW_STATE_MAXIMIZED;
         }
@@ -119,16 +119,17 @@ void WindowContextBase::process_state(GdkEventWindowState* event) {
             stateChangeEvent = com_sun_glass_events_WindowEvent_MAXIMIZE;
         } else {
             stateChangeEvent = com_sun_glass_events_WindowEvent_RESTORE;
-            if ((gdk_windowManagerFunctions & GDK_FUNC_MINIMIZE) == 0) {
+            if ((gdk_windowManagerFunctions & GDK_FUNC_MINIMIZE) == 0
+                || (gdk_windowManagerFunctions & GDK_FUNC_MAXIMIZE) == 0) {
                 // in this case - the window manager will not support the programatic
-                // request to iconify - so we need to restore it now.
+                // request to iconify / maximize - so we need to restore it now.
                 gdk_window_set_functions(gdk_window, gdk_windowManagerFunctions);
             }
         }
 
         notify_state(stateChangeEvent);
     } else if (event->changed_mask & GDK_WINDOW_STATE_ABOVE) {
-        notify_on_top( event->new_window_state & GDK_WINDOW_STATE_ABOVE);
+        notify_on_top(event->new_window_state & GDK_WINDOW_STATE_ABOVE);
     }
 }
 
@@ -148,7 +149,8 @@ void WindowContextBase::process_focus(GdkEventFocus* event) {
     if (jwindow) {
         if (!event->in || isEnabled()) {
             mainEnv->CallVoidMethod(jwindow, jWindowNotifyFocus,
-                    event->in ? com_sun_glass_events_WindowEvent_FOCUS_GAINED : com_sun_glass_events_WindowEvent_FOCUS_LOST);
+                    event->in ? com_sun_glass_events_WindowEvent_FOCUS_GAINED
+                              : com_sun_glass_events_WindowEvent_FOCUS_LOST);
             CHECK_JNI_EXCEPTION(mainEnv)
         } else {
             // when the user tries to activate a disabled window, send FOCUS_DISABLED
@@ -512,20 +514,16 @@ void WindowContextBase::process_key(GdkEventKey* event) {
     }
 }
 
-void WindowContextBase::paint(void* data, jint width, jint height)
-{
-    if (!is_visible()) {
-        return;
-    }
+void WindowContextBase::paint(void* data, jint width, jint height) {
 #ifdef GLASS_GTK3
-    cairo_region_t *region = gdk_window_get_clip_region(gdk_window);
+    cairo_rectangle_int_t rect = {0, 0, width, height};
+    cairo_region_t *region = cairo_region_create_rectangle(&rect);
     gdk_window_begin_paint_region(gdk_window, region);
 #endif
-    cairo_t* context;
-    context = gdk_cairo_create(gdk_window);
+    cairo_t* context = gdk_cairo_create(gdk_window);
 
-    cairo_surface_t* cairo_surface;
-    cairo_surface = cairo_image_surface_create_for_data(
+    cairo_surface_t* cairo_surface =
+        cairo_image_surface_create_for_data(
             (unsigned char*)data,
             CAIRO_FORMAT_ARGB32,
             width, height, width * 4);
@@ -533,8 +531,9 @@ void WindowContextBase::paint(void* data, jint width, jint height)
     applyShapeMask(data, width, height);
 
     cairo_set_source_surface(context, cairo_surface, 0, 0);
-    cairo_set_operator (context, CAIRO_OPERATOR_SOURCE);
+    cairo_set_operator(context, CAIRO_OPERATOR_SOURCE);
     cairo_paint(context);
+
 #ifdef GLASS_GTK3
     gdk_window_end_paint(gdk_window);
     cairo_region_destroy(region);
@@ -562,18 +561,9 @@ void WindowContextBase::show_or_hide_children(bool show) {
     }
 }
 
-void WindowContextBase::reparent_children(WindowContext* parent) {
-    std::set<WindowContextTop*>::iterator it;
-    for (it = children.begin(); it != children.end(); ++it) {
-        (*it)->set_owner(parent);
-        parent->add_child(*it);
-    }
-    children.clear();
-}
-
 void WindowContextBase::set_visible(bool visible) {
     if (visible) {
-        gtk_widget_show_all(gtk_widget);
+        gtk_widget_show(gtk_widget);
     } else {
         gtk_widget_hide(gtk_widget);
         if (jview && is_mouse_entered) {
@@ -596,7 +586,6 @@ bool WindowContextBase::is_visible() {
 }
 
 bool WindowContextBase::set_view(jobject view) {
-
     if (jview) {
         mainEnv->CallVoidMethod(jview, jViewNotifyMouse,
                 com_sun_glass_events_MouseEvent_EXIT,
@@ -700,9 +689,50 @@ WindowContextBase::~WindowContextBase() {
 }
 
 ////////////////////////////// WindowContextTop /////////////////////////////////
-WindowFrameExtents WindowContextTop::normal_extents = {28, 1, 1, 1};
-WindowFrameExtents WindowContextTop::utility_extents = {28, 1, 1, 1};
 
+
+// Work-around because frame extents are only obtained after window is shown.
+// This is used to know the total window size (content + decoration)
+// The first window will have a duplicated resize event, subsequent windows will use the cached value.
+WindowFrameExtents WindowContextTop::normal_extents = {0, 0, 0, 0};
+WindowFrameExtents WindowContextTop::utility_extents = {0, 0, 0, 0};
+
+static int geometry_get_window_width(const WindowGeometry *windowGeometry) {
+     return (windowGeometry->final_width.type == BOUNDSTYPE_WINDOW)
+                   ? windowGeometry->final_width.value
+                   : windowGeometry->final_width.value
+                         + windowGeometry->extents.left
+                         + windowGeometry->extents.right;
+}
+
+static int geometry_get_window_height(const WindowGeometry *windowGeometry) {
+    return (windowGeometry->final_height.type == BOUNDSTYPE_WINDOW)
+                   ? windowGeometry->final_height.value
+                   : windowGeometry->final_height.value
+                         + windowGeometry->extents.top
+                         + windowGeometry->extents.bottom;
+}
+
+static int geometry_get_content_width(WindowGeometry *windowGeometry) {
+    return (windowGeometry->final_width.type == BOUNDSTYPE_CONTENT)
+                   ? windowGeometry->final_width.value
+                   : windowGeometry->final_width.value
+                         - windowGeometry->extents.left
+                         - windowGeometry->extents.right;
+}
+
+static int geometry_get_content_height(WindowGeometry *windowGeometry) {
+    return (windowGeometry->final_height.type == BOUNDSTYPE_CONTENT)
+                   ? windowGeometry->final_height.value
+                   : windowGeometry->final_height.value
+                         - windowGeometry->extents.top
+                         - windowGeometry->extents.bottom;
+}
+
+static GdkAtom get_net_frame_extents_atom() {
+    static const char * extents_str = "_NET_FRAME_EXTENTS";
+    return gdk_atom_intern(extents_str, FALSE);
+}
 
 WindowContextTop::WindowContextTop(jobject _jwindow, WindowContext* _owner, long _screen,
         WindowFrameType _frame_type, WindowType type, GdkWMFunction wmf) :
@@ -713,16 +743,11 @@ WindowContextTop::WindowContextTop(jobject _jwindow, WindowContext* _owner, long
             owner(_owner),
             geometry(),
             resizable(),
-            frame_extents_initialized(),
-            map_received(false),
-            location_assigned(false),
-            size_assigned(false),
             on_top(false),
-            requested_bounds()
-{
+            is_fullscreen(false) {
     jwindow = mainEnv->NewGlobalRef(_jwindow);
 
-    gtk_widget =  gtk_window_new(type == POPUP ? GTK_WINDOW_POPUP : GTK_WINDOW_TOPLEVEL);
+    gtk_widget = gtk_window_new(type == POPUP ? GTK_WINDOW_POPUP : GTK_WINDOW_TOPLEVEL);
 
     if (gchar* app_name = get_application_name()) {
         gtk_window_set_wmclass(GTK_WINDOW(gtk_widget), app_name, app_name);
@@ -740,6 +765,9 @@ WindowContextTop::WindowContextTop(jobject _jwindow, WindowContext* _owner, long
         gtk_window_set_type_hint(GTK_WINDOW(gtk_widget), GDK_WINDOW_TYPE_HINT_UTILITY);
     }
 
+    const char* wm_name = gdk_x11_screen_get_window_manager_name(gdk_screen_get_default());
+    wmanager = (g_strcmp0("Compiz", wm_name) == 0) ? COMPIZ : UNKNOWN;
+
 //    glong xdisplay = (glong)mainEnv->GetStaticLongField(jApplicationCls, jApplicationDisplay);
 //    gint  xscreenID = (gint)mainEnv->GetStaticIntField(jApplicationCls, jApplicationScreen);
     glong xvisualID = (glong)mainEnv->GetStaticLongField(jApplicationCls, jApplicationVisualID);
@@ -749,16 +777,11 @@ WindowContextTop::WindowContextTop(jobject _jwindow, WindowContext* _owner, long
         glass_gtk_window_configure_from_visual(gtk_widget, visual);
     }
 
-    gtk_widget_set_size_request(gtk_widget, 0, 0);
     gtk_widget_set_events(gtk_widget, GDK_FILTERED_EVENTS_MASK);
     gtk_widget_set_app_paintable(gtk_widget, TRUE);
-    if (frame_type != TITLED) {
-        gtk_window_set_decorated(GTK_WINDOW(gtk_widget), FALSE);
-    }
-
     glass_gtk_configure_transparency_and_realize(gtk_widget, frame_type == TRANSPARENT);
-    gtk_window_set_title(GTK_WINDOW(gtk_widget), "");
 
+    gtk_window_set_title(GTK_WINDOW(gtk_widget), "");
     gdk_window = gtk_widget_get_window(gtk_widget);
     gdk_window_set_events(gdk_window, GDK_FILTERED_EVENTS_MASK);
 
@@ -771,11 +794,12 @@ WindowContextTop::WindowContextTop(jobject _jwindow, WindowContext* _owner, long
         gdk_window_set_functions(gdk_window, wmf);
     }
 
-    if (frame_type == TITLED) {
+    if (frame_type != TITLED) {
+        gtk_window_set_decorated(GTK_WINDOW(gtk_widget), FALSE);
+    } else {
         request_frame_extents();
+        geometry.extents = get_cached_extents();
     }
-
-    event_serial = GDK_CURRENT_TIME;
 }
 
 // Applied to a temporary full screen window to prevent sending events to Java
@@ -790,16 +814,10 @@ void WindowContextTop::detach_from_java() {
     }
 }
 
-static GdkAtom
-get_net_frame_extents_atom() {
-    static const char * extents_str = "_NET_FRAME_EXTENTS";
-    return gdk_atom_intern(extents_str, TRUE);
-}
-
-void
-WindowContextTop::request_frame_extents() {
+void WindowContextTop::request_frame_extents() {
     Display *display = GDK_DISPLAY_XDISPLAY(gdk_window_get_display(gdk_window));
-    Atom rfeAtom = XInternAtom(display, "_NET_REQUEST_FRAME_EXTENTS", True);
+    static Atom rfeAtom = XInternAtom(display, "_NET_REQUEST_FRAME_EXTENTS", False);
+
     if (rfeAtom != None) {
         XClientMessageEvent clientMessage;
         memset(&clientMessage, 0, sizeof(clientMessage));
@@ -816,25 +834,45 @@ WindowContextTop::request_frame_extents() {
     }
 }
 
-void WindowContextTop::activate_window() {
-    Display *display = GDK_DISPLAY_XDISPLAY (gdk_window_get_display (gdk_window));
-    Atom navAtom = XInternAtom(display, "_NET_ACTIVE_WINDOW", True);
-    if (navAtom != None) {
-        XClientMessageEvent clientMessage;
-        memset(&clientMessage, 0, sizeof(clientMessage));
+void WindowContextTop::update_frame_extents() {
+    int top, left, bottom, right;
 
-        clientMessage.type = ClientMessage;
-        clientMessage.window = GDK_WINDOW_XID(gdk_window);
-        clientMessage.message_type = navAtom;
-        clientMessage.format = 32;
-        clientMessage.data.l[0] = 1;
-        clientMessage.data.l[1] = gdk_x11_get_server_time(gdk_window);
-        clientMessage.data.l[2] = 0;
+    if (get_frame_extents_property(&top, &left, &bottom, &right)) {
+        if (top > 0 || right > 0 || bottom > 0 || left > 0) {
+            bool changed = geometry.extents.top != top
+                            || geometry.extents.left != left
+                            || geometry.extents.bottom != bottom
+                            || geometry.extents.right != right;
 
-        XSendEvent(display, XDefaultRootWindow(display), False,
-                   SubstructureRedirectMask | SubstructureNotifyMask,
-                   (XEvent *) &clientMessage);
-        XFlush(display);
+            if (changed) {
+                geometry.extents.top = top;
+                geometry.extents.left = left;
+                geometry.extents.bottom = bottom;
+                geometry.extents.right = right;
+
+                set_cached_extents(geometry.extents);
+
+                // set bounds again to correct window size
+                // accounting decorations
+                int w = geometry_get_window_width(&geometry);
+                int h = geometry_get_window_height(&geometry);
+                int cw = geometry_get_content_width(&geometry);
+                int ch = geometry_get_content_height(&geometry);
+
+                int x = geometry.x;
+                int y = geometry.y;
+
+                if (geometry.gravity_x != 0) {
+                    x -= geometry.gravity_x * (float) (left + right);
+                }
+
+                if (geometry.gravity_y != 0) {
+                    y -= geometry.gravity_y * (float) (top + bottom);
+                }
+
+                set_bounds(x, y, true, true, w, h, cw, ch, 0, 0);
+           }
+        }
     }
 }
 
@@ -850,30 +888,7 @@ WindowFrameExtents WindowContextTop::get_cached_extents() {
     return window_type == NORMAL ? normal_extents : utility_extents;
 }
 
-
-bool WindowContextTop::update_frame_extents() {
-    bool changed = false;
-    int top, left, bottom, right;
-    if (get_frame_extents_property(&top, &left, &bottom, &right)) {
-        changed = geometry.extents.top != top
-                    || geometry.extents.left != left
-                    || geometry.extents.bottom != bottom
-                    || geometry.extents.right != right;
-        if (changed) {
-            geometry.extents.top = top;
-            geometry.extents.left = left;
-            geometry.extents.bottom = bottom;
-            geometry.extents.right = right;
-            if (!is_null_extents()) {
-                set_cached_extents(geometry.extents);
-            }
-        }
-    }
-    return changed;
-}
-
-bool
-WindowContextTop::get_frame_extents_property(int *top, int *left,
+bool WindowContextTop::get_frame_extents_property(int *top, int *left,
         int *bottom, int *right) {
     unsigned long *extents;
 
@@ -899,75 +914,11 @@ WindowContextTop::get_frame_extents_property(int *top, int *left,
     return false;
 }
 
-static int geometry_get_window_width(const WindowGeometry *windowGeometry) {
-     return (windowGeometry->final_width.type != BOUNDSTYPE_WINDOW)
-                   ? windowGeometry->final_width.value
-                         + windowGeometry->extents.left
-                         + windowGeometry->extents.right
-                   : windowGeometry->final_width.value;
-}
-
-static int geometry_get_window_height(const WindowGeometry *windowGeometry) {
-    return (windowGeometry->final_height.type != BOUNDSTYPE_WINDOW)
-                   ? windowGeometry->final_height.value
-                         + windowGeometry->extents.top
-                         + windowGeometry->extents.bottom
-                   : windowGeometry->final_height.value;
-}
-
-static int geometry_get_content_width(WindowGeometry *windowGeometry) {
-    return (windowGeometry->final_width.type != BOUNDSTYPE_CONTENT)
-                   ? windowGeometry->final_width.value
-                         - windowGeometry->extents.left
-                         - windowGeometry->extents.right
-                   : windowGeometry->final_width.value;
-}
-static int geometry_get_content_height(WindowGeometry *windowGeometry) {
-    return (windowGeometry->final_height.type != BOUNDSTYPE_CONTENT)
-                   ? windowGeometry->final_height.value
-                         - windowGeometry->extents.top
-                         - windowGeometry->extents.bottom
-                   : windowGeometry->final_height.value;
-}
-
-static int geometry_get_window_x(const WindowGeometry *windowGeometry) {
-    float value = windowGeometry->refx;
-    if (windowGeometry->gravity_x != 0) {
-        value -= geometry_get_window_width(windowGeometry)
-                     * windowGeometry->gravity_x;
-    }
-    return (int) value;
-}
-
-static int geometry_get_window_y(const WindowGeometry *windowGeometry) {
-    float value = windowGeometry->refy;
-    if (windowGeometry->gravity_y != 0) {
-        value -= geometry_get_window_height(windowGeometry)
-                     * windowGeometry->gravity_y;
-    }
-    return (int) value;
-}
-
-static void geometry_set_window_x(WindowGeometry *windowGeometry, int value) {
-    float newValue = value;
-    if (windowGeometry->gravity_x != 0) {
-        newValue += geometry_get_window_width(windowGeometry)
-                * windowGeometry->gravity_x;
-    }
-    windowGeometry->refx = newValue;
-}
-
-static void geometry_set_window_y(WindowGeometry *windowGeometry, int value) {
-    float newValue = value;
-    if (windowGeometry->gravity_y != 0) {
-        newValue += geometry_get_window_height(windowGeometry)
-                * windowGeometry->gravity_y;
-    }
-    windowGeometry->refy = newValue;
-}
-
-void WindowContextTop::process_net_wm_property() {
+void WindowContextTop::work_around_compiz_state() {
     // Workaround for https://bugs.launchpad.net/unity/+bug/998073
+    if (wmanager != COMPIZ) {
+        return;
+    }
 
     static GdkAtom atom_atom = gdk_atom_intern_static_string("ATOM");
     static GdkAtom atom_net_wm_state = gdk_atom_intern_static_string("_NET_WM_STATE");
@@ -1008,86 +959,72 @@ void WindowContextTop::process_net_wm_property() {
 void WindowContextTop::process_property_notify(GdkEventProperty* event) {
     static GdkAtom atom_net_wm_state = gdk_atom_intern_static_string("_NET_WM_STATE");
 
-    if (event->atom == atom_net_wm_state && event->window == gdk_window) {
-        process_net_wm_property();
+    if (event->window == gdk_window) {
+        if (event->atom == get_net_frame_extents_atom()) {
+            update_frame_extents();
+        } else if (event->atom == atom_net_wm_state) {
+            work_around_compiz_state();
+        }
     }
 }
 
+void WindowContextTop::process_state(GdkEventWindowState* event) {
+    if (event->changed_mask & GDK_WINDOW_STATE_FULLSCREEN) {
+        is_fullscreen = event->new_window_state & GDK_WINDOW_STATE_FULLSCREEN;
+    }
+
+    if (event->changed_mask & GDK_WINDOW_STATE_MAXIMIZED
+        && !(event->new_window_state & GDK_WINDOW_STATE_MAXIMIZED)) {
+        gtk_window_resize(GTK_WINDOW(gtk_widget), geometry_get_content_width(&geometry),
+                                    geometry_get_content_height(&geometry));
+    }
+
+    WindowContextBase::process_state(event);
+}
+
 void WindowContextTop::process_configure(GdkEventConfigure* event) {
-    gint x, y, w, h;
-    bool updateWindowConstraints = false;
-    if (gtk_window_get_decorated(GTK_WINDOW(gtk_widget))) {
-        GdkRectangle frame;
-        gint top, left, bottom, right;
+    int ww = event->width + geometry.extents.left + geometry.extents.right;
+    int wh = event->height + geometry.extents.top + geometry.extents.bottom;
 
-        gdk_window_get_frame_extents(gdk_window, &frame);
-#ifdef GLASS_GTK3
-        gdk_window_get_geometry(gdk_window, NULL, NULL, &w, &h);
-#else
-        gdk_window_get_geometry(gdk_window, NULL, NULL, &w, &h, NULL);
-#endif
-        x = frame.x;
-        y = frame.y;
-        geometry.current_width = frame.width;
-        geometry.current_height = frame.height;
+    if (!is_maximized && !is_fullscreen) {
+        geometry.final_width.value = (geometry.final_width.type == BOUNDSTYPE_CONTENT)
+                ? event->width : ww;
 
-        if (update_frame_extents()) {
-            updateWindowConstraints = true;
-            if (!frame_extents_initialized && !is_null_extents()) {
-                frame_extents_initialized = true;
-                set_bounds(0, 0, false, false,
-                    requested_bounds.width, requested_bounds.height,
-                    requested_bounds.client_width, requested_bounds.client_height
-                );
-            }
-        }
-    } else {
-        x = event->x;
-        y = event->y;
-        w = event->width;
-        h = event->height;
+        geometry.final_height.value = (geometry.final_height.type == BOUNDSTYPE_CONTENT)
+                ? event->height : wh;
     }
 
-    if (size_assigned && w <= 1 && h <= 1 && (geometry.final_width.value > 1 ||
-                                             geometry.final_height.value > 1)) {
-        // skip artifact
-        return;
-   }
-
-    // JDK-8232811: to avoid conflicting events, update the geometry only after window pops.
-    if (map_received) {
-        geometry.final_width.value = w;
-        geometry.final_width.type = BOUNDSTYPE_CONTENT;
-        geometry.final_height.value = h;
-        geometry.final_height.type = BOUNDSTYPE_CONTENT;
-    }
-
-    geometry_set_window_x(&geometry, x);
-    geometry_set_window_y(&geometry, y);
-
-    if (jview) {
-        mainEnv->CallVoidMethod(jview, jViewNotifyResize,
-                event->width,
-                event->height);
-        CHECK_JNI_EXCEPTION(mainEnv)
-        mainEnv->CallVoidMethod(jview, jViewNotifyView,
-                com_sun_glass_events_ViewEvent_MOVE);
-        CHECK_JNI_EXCEPTION(mainEnv)
-    }
-    if (jwindow) {
+    // Do not report if iconified, because Java side would set the state to NORMAL
+    if (jwindow && !is_iconified) {
         mainEnv->CallVoidMethod(jwindow, jWindowNotifyResize,
                 (is_maximized)
                     ? com_sun_glass_events_WindowEvent_MAXIMIZE
                     : com_sun_glass_events_WindowEvent_RESIZE,
-                geometry.current_width,
-                geometry.current_height);
+                ww, wh);
         CHECK_JNI_EXCEPTION(mainEnv)
 
-        mainEnv->CallVoidMethod(jwindow, jWindowNotifyMove, x, y);
-        CHECK_JNI_EXCEPTION(mainEnv)
+        if (jview) {
+            mainEnv->CallVoidMethod(jview, jViewNotifyResize, event->width, event->height);
+            CHECK_JNI_EXCEPTION(mainEnv)
+        }
     }
 
-    glong to_screen = getScreenPtrForLocation(x, y);
+    int x, y;
+
+    if (frame_type == TITLED) {
+        GdkRectangle rect;
+        gdk_window_get_frame_extents(gdk_window, &rect);
+        x = rect.x;
+        y = rect.y;
+    } else {
+        gdk_window_get_origin(gdk_window, &x, &y);
+    }
+
+    geometry.x = x;
+    geometry.y = y;
+    notify_window_move();
+
+    glong to_screen = getScreenPtrForLocation(geometry.x, geometry.y);
     if (to_screen != -1) {
         if (to_screen != screen) {
             if (jwindow) {
@@ -1099,75 +1036,51 @@ void WindowContextTop::process_configure(GdkEventConfigure* event) {
             screen = to_screen;
         }
     }
-
-    if (resizable.request != REQUEST_NONE) {
-        set_window_resizable(resizable.request == REQUEST_RESIZABLE);
-        resizable.request = REQUEST_NONE;
-    } else if (!resizable.value) {
-        set_window_resizable(false);
-    } else if (updateWindowConstraints) {
-        update_window_constraints();
-    }
 }
 
 void WindowContextTop::update_window_constraints() {
-    if (resizable.value) {
-        GdkGeometry geom = {
-            (resizable.minw == -1) ? 1
-                    : resizable.minw - geometry.extents.left - geometry.extents.right,
-            (resizable.minh == -1) ? 1
-                    : resizable.minh - geometry.extents.top - geometry.extents.bottom,
-            (resizable.maxw == -1) ? 100000
-                    : resizable.maxw - geometry.extents.left - geometry.extents.right,
-            (resizable.maxh == -1) ? 100000
-                    : resizable.maxh - geometry.extents.top - geometry.extents.bottom,
-            0, 0, 0, 0, 0.0, 0.0, GDK_GRAVITY_NORTH_WEST
-        };
-        gtk_window_set_geometry_hints(GTK_WINDOW(gtk_widget), NULL, &geom,
-                static_cast<GdkWindowHints> (GDK_HINT_MIN_SIZE | GDK_HINT_MAX_SIZE));
-    }
-}
+    GdkGeometry hints;
 
-void WindowContextTop::set_window_resizable(bool res) {
-    if(!res) {
+    if (resizable.value && !is_disabled) {
+        int min_w = (resizable.minw == -1) ? 1
+                      : resizable.minw - geometry.extents.left - geometry.extents.right;
+        int min_h =  (resizable.minh == -1) ? 1
+                      : resizable.minh - geometry.extents.top - geometry.extents.bottom;
+
+        hints.min_width = (min_w < 1) ? 1 : min_w;
+        hints.min_height = (min_h < 1) ? 1 : min_h;
+
+        hints.max_width = (resizable.maxw == -1) ? G_MAXINT
+                            : resizable.maxw - geometry.extents.left - geometry.extents.right;
+
+        hints.max_height = (resizable.maxh == -1) ? G_MAXINT
+                           : resizable.maxh - geometry.extents.top - geometry.extents.bottom;
+    } else {
         int w = geometry_get_content_width(&geometry);
         int h = geometry_get_content_height(&geometry);
-        if (w == -1 && h == -1) {
-            gtk_window_get_size(GTK_WINDOW(gtk_widget), &w, &h);
-        }
-        GdkGeometry geom = {w, h, w, h, 0, 0, 0, 0, 0.0, 0.0, GDK_GRAVITY_NORTH_WEST};
-        gtk_window_set_geometry_hints(GTK_WINDOW(gtk_widget), NULL, &geom,
-                static_cast<GdkWindowHints>(GDK_HINT_MIN_SIZE | GDK_HINT_MAX_SIZE));
-        resizable.value = false;
-    } else {
-        resizable.value = true;
-        update_window_constraints();
+
+        hints.min_width = w;
+        hints.min_height = h;
+        hints.max_width = w;
+        hints.max_height = h;
     }
+
+    gtk_window_set_geometry_hints(GTK_WINDOW(gtk_widget), NULL, &hints,
+                                  (GdkWindowHints)(GDK_HINT_MIN_SIZE | GDK_HINT_MAX_SIZE));
 }
 
 void WindowContextTop::set_resizable(bool res) {
-    resizable.prev = false;
-    gint w, h;
-    gtk_window_get_size(GTK_WINDOW(gtk_widget), &w, &h);
-    if (map_received || w > 1 || h > 1) {
-        set_window_resizable(res);
-    } else {
-        //Since window is not ready yet set only request for change of resizable.
-        resizable.request  = res ? REQUEST_RESIZABLE : REQUEST_NOT_RESIZABLE;
-    }
+    resizable.value = res;
+    update_window_constraints();
 }
 
-void WindowContextTop::set_visible(bool visible)
-{
-    if (visible) {
-        if (!size_assigned) {
-            set_bounds(0, 0, false, false, 320, 200, -1, -1);
-        }
-        if (!location_assigned) {
-            set_bounds(0, 0, true, true, -1, -1, -1, -1);
-        }
-    }
+void WindowContextTop::set_visible(bool visible) {
     WindowContextBase::set_visible(visible);
+
+    if (visible && !geometry.size_assigned) {
+        set_bounds(0, 0, false, false, 320, 200, -1, -1, 0, 0);
+    }
+
     //JDK-8220272 - fire event first because GDK_FOCUS_CHANGE is not always in order
     if (visible && jwindow && isEnabled()) {
         mainEnv->CallVoidMethod(jwindow, jWindowNotifyFocus, com_sun_glass_events_WindowEvent_FOCUS_GAINED);
@@ -1175,142 +1088,60 @@ void WindowContextTop::set_visible(bool visible)
     }
 }
 
-void WindowContextTop::set_bounds(int x, int y, bool xSet, bool ySet, int w, int h, int cw, int ch) {
-    requested_bounds.width = w;
-    requested_bounds.height = h;
-    requested_bounds.client_width = cw;
-    requested_bounds.client_height = ch;
+void WindowContextTop::set_bounds(int x, int y, bool xSet, bool ySet, int w, int h, int cw, int ch,
+                                  float gravity_x, float gravity_y) {
+//     fprintf(stderr, "set_bounds -> x = %d, y = %d, xset = %d, yset = %d, w = %d, h = %d, cw = %d, ch = %d, gx = %f, gy = %f\n",
+//            x, y, xSet, ySet, w, h, cw, ch, gravity_x, gravity_y);
+    // newW / newH are view/content sizes
+    int newW = 0;
+    int newH = 0;
 
-    if (!frame_extents_initialized && frame_type == TITLED) {
-        update_frame_extents();
-        if (is_null_extents()) {
-            if (!is_null_extents(get_cached_extents())) {
-                geometry.extents = get_cached_extents();
-            }
-        } else {
-            frame_extents_initialized = true;
-        }
-    }
+    geometry.gravity_x = gravity_x;
+    geometry.gravity_y = gravity_y;
 
-    XWindowChanges windowChanges;
-    unsigned int windowChangesMask = 0;
     if (w > 0) {
-        geometry.final_width.value = w;
         geometry.final_width.type = BOUNDSTYPE_WINDOW;
-        geometry.current_width = geometry_get_window_width(&geometry);
-        windowChanges.width = geometry_get_content_width(&geometry);
-        windowChangesMask |= CWWidth;
+        geometry.final_width.value = w;
+        newW = w - (geometry.extents.left + geometry.extents.right);
     } else if (cw > 0) {
-        geometry.final_width.value = cw;
         geometry.final_width.type = BOUNDSTYPE_CONTENT;
-        geometry.current_width = geometry_get_window_width(&geometry);
-        windowChanges.width = geometry_get_content_width(&geometry);
-        windowChangesMask |= CWWidth;
+        geometry.final_width.value = cw;
+        newW = cw;
     }
 
     if (h > 0) {
-        geometry.final_height.value = h;
         geometry.final_height.type = BOUNDSTYPE_WINDOW;
-        geometry.current_height = geometry_get_window_height(&geometry);
-        windowChanges.height = geometry_get_content_height(&geometry);
-        windowChangesMask |= CWHeight;
+        geometry.final_height.value = h;
+        newH = h - (geometry.extents.top + geometry.extents.bottom);
     } else if (ch > 0) {
-        geometry.final_height.value = ch;
         geometry.final_height.type = BOUNDSTYPE_CONTENT;
-        geometry.current_height = geometry_get_window_height(&geometry);
-        windowChanges.height = geometry_get_content_height(&geometry);
-        windowChangesMask |= CWHeight;
+        geometry.final_height.value = ch;
+        newH = ch;
+    }
+
+    if (newW > 0 || newH > 0) {
+        // call update_window_constraints() to let gtk_window_resize succeed, because it's bound to geometry constraints
+        update_window_constraints();
+        gtk_window_resize(GTK_WINDOW(gtk_widget), newW, newH);
+        geometry.size_assigned = true;
+        notify_window_resize();
     }
 
     if (xSet || ySet) {
         if (xSet) {
-            geometry.refx = x + geometry.current_width * geometry.gravity_x;
+            geometry.x = x;
         }
-
-        windowChanges.x = geometry_get_window_x(&geometry);
-        windowChangesMask |= CWX;
 
         if (ySet) {
-            geometry.refy = y + geometry.current_height * geometry.gravity_y;
+            geometry.y = y;
         }
 
-        windowChanges.y = geometry_get_window_y(&geometry);
-        windowChangesMask |= CWY;
-
-        location_assigned = true;
-    }
-
-    if (w > 0 || h > 0 || cw > 0 || ch > 0) size_assigned = true;
-
-    window_configure(&windowChanges, windowChangesMask);
-
-}
-
-void WindowContextTop::process_map() {
-    map_received = true;
-}
-
-void WindowContextTop::window_configure(XWindowChanges *windowChanges,
-        unsigned int windowChangesMask) {
-    if (windowChangesMask == 0) {
-        return;
-    }
-
-    if (windowChangesMask & (CWX | CWY)) {
-        gint newX, newY;
-        gtk_window_get_position(GTK_WINDOW(gtk_widget), &newX, &newY);
-
-        if (windowChangesMask & CWX) {
-            newX = windowChanges->x;
-        }
-        if (windowChangesMask & CWY) {
-            newY = windowChanges->y;
-        }
-        gtk_window_move(GTK_WINDOW(gtk_widget), newX, newY);
-    }
-
-    if (windowChangesMask & (CWWidth | CWHeight)) {
-        gint newWidth, newHeight;
-        gtk_window_get_size(GTK_WINDOW(gtk_widget), &newWidth, &newHeight);
-
-        if (windowChangesMask & CWWidth) {
-            newWidth = windowChanges->width;
-        }
-        if (windowChangesMask & CWHeight) {
-            newHeight = windowChanges->height;
-        }
-
-        if (!resizable.value) {
-            GdkGeometry geom;
-            GdkWindowHints hints = (GdkWindowHints)(GDK_HINT_MIN_SIZE | GDK_HINT_MAX_SIZE);
-            geom.min_width = geom.max_width = newWidth;
-            geom.min_height = geom.max_height = newHeight;
-            gtk_window_set_geometry_hints(GTK_WINDOW(gtk_widget), NULL, &geom, hints);
-        }
-        gtk_window_resize(GTK_WINDOW(gtk_widget), newWidth, newHeight);
-
-        //JDK-8193502: Moved here from WindowContextBase::set_view because set_view is called
-        //first and the size is not set yet. This also guarantees that the size will be correct
-        //see: gtk_window_get_size doc for more context.
-        if (jview) {
-            mainEnv->CallVoidMethod(jview, jViewNotifyResize, newWidth, newHeight);
-            CHECK_JNI_EXCEPTION(mainEnv);
-        }
+        gtk_window_move(GTK_WINDOW(gtk_widget), geometry.x, geometry.y);
+        notify_window_move();
     }
 }
 
-void WindowContextTop::process_key(GdkEventKey* event) {
-    WindowContextBase::process_key(event);
-    event_serial = event->time;
-}
-
-void WindowContextTop::process_mouse_button(GdkEventButton* event) {
-    WindowContextBase::process_mouse_button(event);
-    event_serial = event->time;
-}
-
-void WindowContextTop::applyShapeMask(void* data, uint width, uint height)
-{
+void WindowContextTop::applyShapeMask(void* data, uint width, uint height) {
     if (frame_type != TRANSPARENT) {
         return;
     }
@@ -1318,25 +1149,10 @@ void WindowContextTop::applyShapeMask(void* data, uint width, uint height)
     glass_window_apply_shape_mask(gtk_widget_get_window(gtk_widget), data, width, height);
 }
 
-void WindowContextTop::ensure_window_size() {
-    gint w, h;
-#ifdef GLASS_GTK3
-    gdk_window_get_geometry(gdk_window, NULL, NULL, &w, &h);
-#else
-    gdk_window_get_geometry(gdk_window, NULL, NULL, &w, &h, NULL);
-#endif
-    if (size_assigned && (geometry.final_width.value != w
-                       || geometry.final_height.value != h)) {
-
-        gdk_window_resize(gdk_window, geometry.final_width.value,
-                                      geometry.final_height.value);
-    }
-}
-
 void WindowContextTop::set_minimized(bool minimize) {
     is_iconified = minimize;
     if (minimize) {
-        if (frame_type == TRANSPARENT) {
+        if (frame_type == TRANSPARENT && wmanager == COMPIZ) {
             // https://bugs.launchpad.net/ubuntu/+source/unity/+bug/1245571
             glass_window_reset_input_shape_mask(gtk_widget_get_window(gtk_widget));
         }
@@ -1350,9 +1166,10 @@ void WindowContextTop::set_minimized(bool minimize) {
         gtk_window_iconify(GTK_WINDOW(gtk_widget));
     } else {
         gtk_window_deiconify(GTK_WINDOW(gtk_widget));
-        activate_window();
+        gdk_window_focus(gdk_window, GDK_CURRENT_TIME);
     }
 }
+
 void WindowContextTop::set_maximized(bool maximize) {
     is_maximized = maximize;
     if (maximize) {
@@ -1361,7 +1178,6 @@ void WindowContextTop::set_maximized(bool maximize) {
         GdkWMFunction wmf = (GdkWMFunction)(gdk_windowManagerFunctions | GDK_FUNC_MAXIMIZE);
         gdk_window_set_functions(gdk_window, wmf);
 
-        ensure_window_size();
         gtk_window_maximize(GTK_WINDOW(gtk_widget));
     } else {
         gtk_window_unmaximize(GTK_WINDOW(gtk_widget));
@@ -1369,8 +1185,8 @@ void WindowContextTop::set_maximized(bool maximize) {
 }
 
 void WindowContextTop::enter_fullscreen() {
-    ensure_window_size();
     gtk_window_fullscreen(GTK_WINDOW(gtk_widget));
+    is_fullscreen = true;
 }
 
 void WindowContextTop::exit_fullscreen() {
@@ -1378,15 +1194,8 @@ void WindowContextTop::exit_fullscreen() {
 }
 
 void WindowContextTop::request_focus() {
-    //JDK-8212060: Window show and then move glitch.
-    //The WindowContextBase::set_visible will take care of showing the window.
-    //The below code will only handle later request_focus.
     if (is_visible()) {
-        // event_serial holds an event serial that will help X11 determine which window should have the focus and
-        // prevents activeWindows on WindowStage.java to be out of order which may cause the FOCUS_DISABLED event
-        // to bring up the wrong window (it brings up the last which will not be the real "last" if out of order).
-        gtk_window_present_with_time(GTK_WINDOW(gtk_widget), event_serial);
-        event_serial = GDK_CURRENT_TIME;
+        gtk_window_present(GTK_WINDOW(gtk_widget));
     }
 }
 
@@ -1395,7 +1204,7 @@ void WindowContextTop::set_focusable(bool focusable) {
 }
 
 void WindowContextTop::set_title(const char* title) {
-    gtk_window_set_title(GTK_WINDOW(gtk_widget),title);
+    gtk_window_set_title(GTK_WINDOW(gtk_widget), title);
 }
 
 void WindowContextTop::set_alpha(double alpha) {
@@ -1403,24 +1212,13 @@ void WindowContextTop::set_alpha(double alpha) {
 }
 
 void WindowContextTop::set_enabled(bool enabled) {
-    if (enabled) {
-        if (resizable.prev) {
-            set_window_resizable(true);
-        }
-    } else {
-        if (resizable.value) {
-            set_window_resizable(false);
-            resizable.prev = true;
-        } else if (resizable.request == REQUEST_RESIZABLE) {
-            resizable.request = REQUEST_NOT_RESIZABLE;
-            resizable.prev = true;
-        }
-    }
+    is_disabled = !enabled;
+    update_window_constraints();
 }
 
 void WindowContextTop::set_minimum_size(int w, int h) {
-    resizable.minw = w;
-    resizable.minh = h;
+    resizable.minw = (w <= 0) ? 1 : w;
+    resizable.minh = (h <= 0) ? 1 : h;
     update_window_constraints();
 }
 
@@ -1434,8 +1232,12 @@ void WindowContextTop::set_icon(GdkPixbuf* pixbuf) {
     gtk_window_set_icon(GTK_WINDOW(gtk_widget), pixbuf);
 }
 
-void WindowContextTop::restack(bool restack) {
-    gdk_window_restack(gdk_window, NULL, restack ? TRUE : FALSE);
+void WindowContextTop::to_front() {
+    gdk_window_raise(gdk_window);
+}
+
+void WindowContextTop::to_back() {
+    gdk_window_lower(gdk_window);
 }
 
 void WindowContextTop::set_modal(bool modal, WindowContext* parent) {
@@ -1454,15 +1256,6 @@ GtkWindow *WindowContextTop::get_gtk_window() {
 
 WindowFrameExtents WindowContextTop::get_frame_extents() {
     return geometry.extents;
-}
-
-void WindowContextTop::set_gravity(float x, float y) {
-    int oldX = geometry_get_window_x(&geometry);
-    int oldY = geometry_get_window_y(&geometry);
-    geometry.gravity_x = x;
-    geometry.gravity_y = y;
-    geometry_set_window_x(&geometry, oldX);
-    geometry_set_window_y(&geometry, oldY);
 }
 
 void WindowContextTop::update_ontop_tree(bool on_top) {
@@ -1527,6 +1320,37 @@ void WindowContextTop::set_level(int level) {
 
 void WindowContextTop::set_owner(WindowContext * owner_ctx) {
     owner = owner_ctx;
+}
+
+void WindowContextTop::notify_window_resize() {
+    int w = geometry_get_window_width(&geometry);
+    int h = geometry_get_window_height(&geometry);
+
+    mainEnv->CallVoidMethod(jwindow, jWindowNotifyResize,
+                 com_sun_glass_events_WindowEvent_RESIZE, w, h);
+    CHECK_JNI_EXCEPTION(mainEnv)
+
+    if (jview) {
+        int cw = geometry_get_content_width(&geometry);
+        int ch = geometry_get_content_height(&geometry);
+
+        mainEnv->CallVoidMethod(jview, jViewNotifyResize, cw, ch);
+        CHECK_JNI_EXCEPTION(mainEnv)
+    }
+}
+
+void WindowContextTop::notify_window_move() {
+    if (jwindow) {
+        mainEnv->CallVoidMethod(jwindow, jWindowNotifyMove,
+                                 geometry.x, geometry.y);
+        CHECK_JNI_EXCEPTION(mainEnv)
+
+        if (jview) {
+            mainEnv->CallVoidMethod(jview, jViewNotifyView,
+                    com_sun_glass_events_ViewEvent_MOVE);
+            CHECK_JNI_EXCEPTION(mainEnv)
+        }
+    }
 }
 
 void WindowContextTop::process_destroy() {


### PR DESCRIPTION
Clean backport of 8260528: Clean glass-gtk sizing and positioning code
Reviewed-by: jvos, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8260528](https://bugs.openjdk.org/browse/JDK-8260528): Clean glass-gtk sizing and positioning code (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/172/head:pull/172` \
`$ git checkout pull/172`

Update a local copy of the PR: \
`$ git checkout pull/172` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 172`

View PR using the GUI difftool: \
`$ git pr show -t 172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/172.diff">https://git.openjdk.org/jfx17u/pull/172.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/172#issuecomment-1859155721)