### PR TITLE
8251240: Menus inaccessible on Linux with i3 wm

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -1010,14 +1010,10 @@ void WindowContextTop::process_configure(GdkEventConfigure* event) {
     }
 
     int x, y;
-
+    gdk_window_get_origin(gdk_window, &x, &y);
     if (frame_type == TITLED) {
-        GdkRectangle rect;
-        gdk_window_get_frame_extents(gdk_window, &rect);
-        x = rect.x;
-        y = rect.y;
-    } else {
-        gdk_window_get_origin(gdk_window, &x, &y);
+        x -= geometry.extents.left;
+        y -= geometry.extents.top;
     }
 
     geometry.x = x;


### PR DESCRIPTION
Clean backport of 8251240: Menus inaccessible on Linux with i3 wm
Reviewed-by: jpereda, jvos

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8251240](https://bugs.openjdk.org/browse/JDK-8251240): Menus inaccessible on Linux with i3 wm (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/173.diff">https://git.openjdk.org/jfx17u/pull/173.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/173#issuecomment-1859162113)