### PR TITLE
8181084: JavaFX show big icons in system menu on macOS with Retina display

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -622,6 +622,7 @@ public abstract class Application {
     }
 
     public abstract Pixels createPixels(int width, int height, ByteBuffer data);
+    public abstract Pixels createPixels(int width, int height, ByteBuffer data, float scalex, float scaley);
     public abstract Pixels createPixels(int width, int height, IntBuffer data);
     public abstract Pixels createPixels(int width, int height, IntBuffer data, float scalex, float scaley);
     protected abstract int staticPixels_getNativeFormat();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Pixels.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Pixels.java
@@ -98,6 +98,20 @@ public abstract class Pixels {
         this.scaley = 1.0f;
     }
 
+    protected Pixels(final int width, final int height, final ByteBuffer pixels, float scalex, float scaley) {
+        this.width = width;
+        this.height = height;
+        this.bytesPerComponent = 1;
+        this.bytes = pixels.slice();
+        if ((this.width <= 0) || (this.height <= 0) || ((this.width * this.height * 4) > this.bytes.capacity())) {
+            throw new IllegalArgumentException("Too small byte buffer size "+this.width+"x"+this.height+" ["+(this.width*this.height*4)+"] > "+this.bytes.capacity());
+        }
+
+        this.ints = null;
+        this.scalex = scalex;
+        this.scaley = scaley;
+    }
+
     protected Pixels(final int width, final int height, IntBuffer pixels) {
         this.width = width;
         this.height = height;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -412,6 +412,11 @@ final class GtkApplication extends Application implements
     }
 
     @Override
+    public Pixels createPixels(int width, int height, ByteBuffer data, float scalex, float scaley) {
+        return new GtkPixels(width, height, data, scalex, scaley);
+    }
+
+    @Override
     public Pixels createPixels(int width, int height, IntBuffer data) {
         return new GtkPixels(width, height, data);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkPixels.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkPixels.java
@@ -35,6 +35,10 @@ final class GtkPixels extends Pixels {
         super(width, height, data);
     }
 
+    public GtkPixels(int width, int height, ByteBuffer data, float scalex, float scaley) {
+        super(width, height, data, scalex, scaley);
+    }
+
     public GtkPixels(int width, int height, IntBuffer data) {
         super(width, height, data);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosApplication.java
@@ -120,6 +120,11 @@ public final class IosApplication extends Application {
         return new IosPixels(width, height, data);
     }
 
+    @Override
+    public Pixels createPixels(int width, int height, ByteBuffer data, float scalex, float scaley) {
+        return new IosPixels(width, height, data, scalex, scaley);
+    }
+
     /**
      * @inheritDoc
      */

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosPixels.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosPixels.java
@@ -38,6 +38,10 @@ final class IosPixels extends Pixels {
         super(width, height, data);
     }
 
+    protected IosPixels(int width, int height, ByteBuffer data, float scalex, float scaley) {
+        super(width, height, data, scalex, scaley);
+    }
+
     protected IosPixels(int width, int height, IntBuffer data) {
         super(width, height, data);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -271,6 +271,10 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
         return new MacPixels(width, height, data);
     }
 
+    @Override public Pixels createPixels(int width, int height, ByteBuffer data, float scalex, float scaley) {
+        return new MacPixels(width, height, data, scalex, scaley);
+    }
+
     @Override public Pixels createPixels(int width, int height, IntBuffer data) {
         return new MacPixels(width, height, data);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacPixels.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacPixels.java
@@ -53,6 +53,10 @@ final class MacPixels extends Pixels {
         super(width, height, data);
     }
 
+    protected MacPixels(int width, int height, ByteBuffer data, float scalex, float scaley) {
+        super(width, height, data, scalex, scaley);
+    }
+
     protected MacPixels(int width, int height, IntBuffer data) {
         super(width, height, data);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
@@ -188,14 +188,17 @@ public final class MonocleApplication extends Application {
     }
 
     @Override
+    public Pixels createPixels(int width, int height, ByteBuffer data, float scalex, float scaley) {
+        return new MonoclePixels(width, height, data, scalex, scaley);
+    }
+
+    @Override
     public Pixels createPixels(int width, int height, IntBuffer data) {
         return new MonoclePixels(width, height, data);
     }
 
     @Override
-    public Pixels createPixels(int width, int height, IntBuffer data,
-                               float scalex, float scaley)
-    {
+    public Pixels createPixels(int width, int height, IntBuffer data, float scalex, float scaley) {
         return new MonoclePixels(width, height, data, scalex, scaley);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonoclePixels.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonoclePixels.java
@@ -37,6 +37,10 @@ final class MonoclePixels extends Pixels {
         super(width, height, data);
     }
 
+    MonoclePixels(int width, int height, ByteBuffer data, float scalex, float scaley) {
+        super(width, height, data, scalex, scaley);
+    }
+
     MonoclePixels(int width, int height, IntBuffer data) {
         super(width, height, data);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
@@ -253,6 +253,11 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
         return new WinPixels(width, height, data);
     }
 
+    @Override
+    public Pixels createPixels(int width, int height, ByteBuffer data, float scalex, float scaley) {
+        return new WinPixels(width, height, data, scalex, scaley);
+    }
+
     @Override public Pixels createPixels(int width, int height, IntBuffer data) {
         return new WinPixels(width, height, data);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinPixels.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinPixels.java
@@ -46,6 +46,10 @@ final class WinPixels extends Pixels {
         super(width, height, data);
     }
 
+    protected WinPixels(int width, int height, ByteBuffer data, float scalex, float scaley) {
+        super(width, height, data, scalex, scaley);
+    }
+
     protected WinPixels(int width, int height, IntBuffer data) {
         super(width, height, data);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PixelUtils.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PixelUtils.java
@@ -96,7 +96,10 @@ class PixelUtils {
                 throw new IllegalArgumentException("non-RGB image format");
             }
             pixels = app.createPixels(image.getWidth(),
-                                      image.getHeight(), bytes);
+                                      image.getHeight(),
+                                      bytes,
+                                      image.getPixelScale(),
+                                      image.getPixelScale());
             return pixels;
         } else if (pixelType == PixelFormat.DataType.INT) {
             if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
@@ -109,7 +112,10 @@ class PixelUtils {
              */
             IntBuffer ints = (IntBuffer)image.getPixelBuffer();
             pixels = app.createPixels(image.getWidth(),
-                                      image.getHeight(), ints);
+                                      image.getHeight(),
+                                      ints,
+                                      image.getPixelScale(),
+                                      image.getPixelScale());
             return pixels;
         } else {
             throw new IllegalArgumentException("unhandled image type: " + pixelType);


### PR DESCRIPTION
clean backport of 8181084: JavaFX show big icons in system menu on macOS with Retina di…splay

Reviewed-by: jpereda, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8181084](https://bugs.openjdk.org/browse/JDK-8181084): JavaFX show big icons in system menu on macOS with Retina display (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/174.diff">https://git.openjdk.org/jfx17u/pull/174.diff</a>

</details>
