### PR TITLE
8321722: Tab header flickering when dragging slowly other tabs and reordering uncompleted

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2142,7 +2142,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         if (dragState == DragState.NONE) {
             return;
         }
-        int dragDirection;
+        int dragDirection = 0;
         double dragHeaderNewLayoutX;
         Bounds dragHeaderBounds;
         Bounds dropHeaderBounds;
@@ -2153,12 +2153,12 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         if (dragDelta > 0) {
             // Dragging the tab header towards higher indexed tab headers inside headersRegion.
             dragDirection = MIN_TO_MAX;
-        } else {
+        } else if (dragDelta < 0) {
             // Dragging the tab header towards lower indexed tab headers inside headersRegion.
             dragDirection = MAX_TO_MIN;
         }
         // Stop dropHeaderAnim if direction of drag is changed
-        if (prevDragDirection != dragDirection) {
+        if (dragDirection != 0 && prevDragDirection != dragDirection) {
             stopAnim(dropHeaderAnim);
             prevDragDirection = dragDirection;
         }


### PR DESCRIPTION
almost clean Backport (apart from a (c) date change) of
8321722: Tab header flickering when dragging slowly other tabs and reordering uncompleted

Reviewed-by: angorya, mstrauss, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321722](https://bugs.openjdk.org/browse/JDK-8321722): Tab header flickering when dragging slowly other tabs and reordering uncompleted (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/177/head:pull/177` \
`$ git checkout pull/177`

Update a local copy of the PR: \
`$ git checkout pull/177` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 177`

View PR using the GUI difftool: \
`$ git pr show -t 177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/177.diff">https://git.openjdk.org/jfx17u/pull/177.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/177#issuecomment-1900064993)