### PR TITLE
8221261: Deadlock on macOS in JFXPanel app when handling IME calls

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -59,6 +59,21 @@ static BOOL disableSyncRendering = NO;
 static BOOL firstActivation = YES;
 static BOOL shouldReactivate = NO;
 
+// Custom NSRunLoopMode constant that matches the one used by AWT in its
+// doAWTRunLoopImpl method. This is not formally documented yet, but all
+// versions of the JDK use it. We might consider a request to document it.
+static NSString* JavaRunLoopMode = @"AWTRunLoopMode";
+
+// List of allowable runLoop modes that Java runnables can run in.
+// This is used when calling performSelectorOnMainThread from
+// the JNI _invokeAndWait and _submitForLaterInvocation methods.
+// We include JavaRunLoopMode in the list of allowable run modes in case
+// we are running on the AWT event thread. This will allow JavaFX
+// runnables to be scheduled when AWT is running doAWTRunLoopImpl
+// on the AppKit thread (which it does for IME callbacks) so that we
+// don't deadlock.
+static NSArray<NSString*> *runLoopModes = nil;
+
 #ifdef STATIC_BUILD
 jint JNICALL JNI_OnLoad_glass(JavaVM *vm, void *reserved)
 #else
@@ -525,6 +540,19 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
             }
         }
 
+        // List of RunLoopModes in which we will run runnables passed
+        // to _invokeAndWait and _invokeAndExit. This includes
+        // JavaRunLoopMode to avoid a possible deadlock with AWT.
+        // There is no harm always adding it, since it will have no
+        // effect if the run loop that receives this message does not
+        // specify it.
+        runLoopModes = [[NSArray alloc] initWithObjects:
+            NSDefaultRunLoopMode,
+            NSModalPanelRunLoopMode,
+            NSEventTrackingRunLoopMode,
+            JavaRunLoopMode,
+            nil];
+
         // Determine if we're running embedded (in AWT, SWT, elsewhere)
         NSApplication *app = [NSApplication sharedApplication];
         isEmbedded = [app isRunning];
@@ -971,7 +999,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1submitForLater
     if (jEnv != NULL)
     {
         GlassRunnable *runnable = [[GlassRunnable alloc] initWithRunnable:(*env)->NewGlobalRef(env, jRunnable)];
-        [runnable performSelectorOnMainThread:@selector(run) withObject:nil waitUntilDone:NO];
+        [runnable performSelectorOnMainThread:@selector(run) withObject:nil waitUntilDone:NO modes:runLoopModes];
     }
 }
 
@@ -989,7 +1017,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1invokeAndWait
     if (jEnv != NULL)
     {
         GlassRunnable *runnable = [[GlassRunnable alloc] initWithRunnable:(*env)->NewGlobalRef(env, jRunnable)];
-        [runnable performSelectorOnMainThread:@selector(run) withObject:nil waitUntilDone:YES];
+        [runnable performSelectorOnMainThread:@selector(run) withObject:nil waitUntilDone:YES modes:runLoopModes];
     }
 }
 


### PR DESCRIPTION
Clean backport of 8221261: Deadlock on macOS in JFXPanel app when handling IME calls

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8221261](https://bugs.openjdk.org/browse/JDK-8221261): Deadlock on macOS in JFXPanel app when handling IME calls (**Bug** - P2)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/178/head:pull/178` \
`$ git checkout pull/178`

Update a local copy of the PR: \
`$ git checkout pull/178` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 178`

View PR using the GUI difftool: \
`$ git pr show -t 178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/178.diff">https://git.openjdk.org/jfx17u/pull/178.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/178#issuecomment-1933650329)