### PR TITLE
8322703: Intermittent crash in WebView in a JFXPanel from IME calls on macOS

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/InputMethodClientImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/InputMethodClientImpl.java
@@ -30,6 +30,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
 import com.sun.javafx.logging.PlatformLogger;
@@ -122,8 +123,25 @@ public final class InputMethodClientImpl
     }
 
     // InputMethodRequests implementation
+
+    private <T> T callOnEventThread(Callable<T> callable) {
+        FutureTask<T> f = new FutureTask<>(callable);
+
+        Invoker.getInvoker().invokeOnEventThread(f);
+        T result = null;
+        try {
+            result = f.get();
+        } catch (ExecutionException ex) {
+            log.severe("InputMethodClientImpl " + ex);
+        } catch (InterruptedException ex) {
+            log.severe("InputMethodClientImpl InterruptedException" + ex);
+        }
+        return result;
+    }
+
+    @Override
     public Point2D getTextLocation(int offset) {
-        FutureTask<Point2D> f = new FutureTask<>(() -> {
+        Point2D result = callOnEventThread((Callable<Point2D>) () -> {
             int[] loc = webPage.getClientTextLocation(offset);
             WCPoint point = webPage.getPageClient().windowToScreen(
                     // We need lower left corner of the char bounds rectangle here
@@ -131,34 +149,16 @@ public final class InputMethodClientImpl
             return new Point2D(point.getIntX(), point.getIntY());
         });
 
-        Invoker.getInvoker().invokeOnEventThread(f);
-        Point2D result = null;
-        try {
-            result = f.get();
-        } catch (ExecutionException ex) {
-            log.severe("InputMethodClientImpl.getTextLocation " + ex);
-        } catch (InterruptedException ex) {
-            log.severe("InputMethodClientImpl.getTextLocation InterruptedException" + ex);
-        }
         return result;
     }
 
     public int getLocationOffset(int x, int y) {
-        FutureTask<Integer> f = new FutureTask<>(() -> {
+        Integer result = callOnEventThread((Callable<Integer>) () -> {
             WCPoint point = webPage.getPageClient().windowToScreen(new WCPoint(0, 0));
             return webPage.getClientLocationOffset(x - point.getIntX(), y - point.getIntY());
         });
 
-        Invoker.getInvoker().invokeOnEventThread(f);
-        int location = 0;
-        try {
-            location = f.get();
-        } catch (ExecutionException ex) {
-            log.severe("InputMethodClientImpl.getLocationOffset " + ex);
-        } catch (InterruptedException ex) {
-            log.severe("InputMethodClientImpl.getTextLocation InterruptedException" + ex);
-        }
-        return location;
+        return result != null ? result : 0;
     }
 
     public void cancelLatestCommittedText() {
@@ -166,25 +166,41 @@ public final class InputMethodClientImpl
     }
 
     public String getSelectedText() {
-        return webPage.getClientSelectedText();
+        String result = callOnEventThread((Callable<String>) () -> {
+            return webPage.getClientSelectedText();
+        });
+
+        return result != null ? result : "";
     }
 
     @Override
     public int getInsertPositionOffset() {
-        return webPage.getClientInsertPositionOffset();
+        Integer result = callOnEventThread((Callable<Integer>) () -> {
+            return webPage.getClientInsertPositionOffset();
+        });
+
+        return result != null ? result : 0;
     }
 
     @Override
     public String getCommittedText(int begin, int end) {
-        try {
-            return webPage.getClientCommittedText().substring(begin, end);
-        } catch (StringIndexOutOfBoundsException e) {
-            throw new IllegalArgumentException(e);
-        }
+        String result = callOnEventThread((Callable<String>) () -> {
+            try {
+                return webPage.getClientCommittedText().substring(begin, end);
+            } catch (StringIndexOutOfBoundsException e) {
+                throw new IllegalArgumentException(e);
+            }
+        });
+
+        return result != null ? result : "";
     }
 
     @Override
     public int getCommittedTextLength() {
-        return webPage.getClientCommittedTextLength();
+        Integer result = callOnEventThread((Callable<Integer>) () -> {
+            return webPage.getClientCommittedTextLength();
+        });
+
+        return result != null ? result : 0;
     }
 }


### PR DESCRIPTION
Almost clean backport of 8322703: Intermittent crash in WebView in a JFXPanel from IME calls on macOS

Reviewed-by: jbhaskar, arapte

Very minor conflicts after cherry picking the commit:
```
     // InputMethodRequests implementation
+<<<<<<< HEAD
+=======
...
     @Override
+>>>>>>> 40809a3f84 (8322703: Intermittent crash in WebView in a JFXPanel from IME calls on macOS)
     public Point2D getTextLocation(int offset) {
```

I fixed it manually, and pushed the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8322703](https://bugs.openjdk.org/browse/JDK-8322703) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322703](https://bugs.openjdk.org/browse/JDK-8322703): Intermittent crash in WebView in a JFXPanel from IME calls on macOS (**Bug** - P2 - Approved)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/179/head:pull/179` \
`$ git checkout pull/179`

Update a local copy of the PR: \
`$ git checkout pull/179` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 179`

View PR using the GUI difftool: \
`$ git pr show -t 179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/179.diff">https://git.openjdk.org/jfx17u/pull/179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/179#issuecomment-1971435285)