### PR TITLE
8271398: GTK3 drag view image swaps red and blue color channels

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp
@@ -928,6 +928,13 @@ GdkPixbuf* DragView::get_drag_image(GtkWidget *widget, gboolean* is_raw_image, g
                     guchar* data = (guchar*) g_try_malloc0(nraw - whsz);
                     if (data) {
                         memcpy(data, (raw + whsz), nraw - whsz);
+
+                        if (is_raw_image) {
+                            guchar* origdata = data;
+                            data = (guchar*) convert_BGRA_to_RGBA((const int*) data, w * 4, h);
+                            g_free(origdata);
+                        }
+
                         pixbuf = gdk_pixbuf_new_from_data(data, GDK_COLORSPACE_RGB, TRUE, 8,
                                                           w, h, w * 4, pixbufDestroyNotifyFunc, NULL);
                     }
@@ -1064,26 +1071,8 @@ void DragView::View::expose()
 {
     cairo_t *context = gdk_cairo_create(gtk_widget_get_window(widget));
 
-    cairo_surface_t* cairo_surface;
-
-    guchar* pixels = is_raw_image
-            ? (guchar*) convert_BGRA_to_RGBA((const int*) gdk_pixbuf_get_pixels(pixbuf),
-                                                gdk_pixbuf_get_rowstride(pixbuf),
-                                                height)
-            : gdk_pixbuf_get_pixels(pixbuf);
-
-    cairo_surface = cairo_image_surface_create_for_data(
-            pixels,
-            CAIRO_FORMAT_ARGB32,
-            width, height, width * 4);
-
-    cairo_set_source_surface(context, cairo_surface, 0, 0);
-    cairo_set_operator(context, CAIRO_OPERATOR_SOURCE);
+    gdk_cairo_set_source_pixbuf(context, pixbuf, 0, 0);
     cairo_paint(context);
 
-    if (is_raw_image) {
-        g_free(pixels);
-    }
     cairo_destroy(context);
-    cairo_surface_destroy(cairo_surface);
 }

--- a/tests/manual/dnd/DndTestDragViewRawImage.java
+++ b/tests/manual/dnd/DndTestDragViewRawImage.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javafx.application.Application;
+import javafx.embed.swing.SwingFXUtils;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.TransferMode;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+import java.awt.image.BufferedImage;
+
+public class DndTestDragViewRawImage extends Application {
+    Image image = createImage(240, 240);
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+    @Override
+    public void start(Stage stage) {
+        ImageView imageView = new ImageView(image);
+        imageView.setOnDragDetected(event -> {
+            ClipboardContent content = new ClipboardContent();
+            content.putImage(image);
+            Dragboard dragboard = imageView.startDragAndDrop(TransferMode.ANY);
+            dragboard.setContent(content);
+            dragboard.setDragView(image);
+        });
+
+        Label label = new Label("Click the image and drag. " +
+                "The drag image displayed with the cursor (drag view) " +
+                "should match the source image");
+
+        VBox vBox = new VBox(label, imageView);
+        vBox.setSpacing(5.0);
+        vBox.setAlignment(Pos.CENTER);
+        stage.setScene(new Scene(vBox, 480, 480));
+        stage.setTitle("Drag View Image Colors");
+        stage.show();
+    }
+
+    private static Image createImage(int width, int height) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                if (x < width * 0.33) {
+                    image.setRGB(x, y, 0xFF0000);
+                } else if (x < width * 0.66) {
+                    image.setRGB(x, y, 0x00FF00);
+                } else {
+                    image.setRGB(x, y, 0x0000FF);
+                }
+            }
+        }
+        return SwingFXUtils.toFXImage(image, null);
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271398](https://bugs.openjdk.org/browse/JDK-8271398) needs maintainer approval

### Issue
 * [JDK-8271398](https://bugs.openjdk.org/browse/JDK-8271398): GTK3 drag view image swaps red and blue color channels (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/180/head:pull/180` \
`$ git checkout pull/180`

Update a local copy of the PR: \
`$ git checkout pull/180` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 180`

View PR using the GUI difftool: \
`$ git pr show -t 180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/180.diff">https://git.openjdk.org/jfx17u/pull/180.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/180#issuecomment-1980757933)