### PR TITLE
8327177: macOS: wrong GlobalRef deleted in GlassMenu

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
@@ -648,6 +648,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacMenuDelegate__1setCallback
         GlassMenu *menu = (GlassMenu *)jlong_to_ptr(jMenuPtr);
         GET_MAIN_JENV;
         (*env)->DeleteGlobalRef(env, menu->jCallback);
+        menu->jCallback = NULL;
         if (jCallback != NULL)
         {
             menu->jCallback = (*env)->NewGlobalRef(env, jCallback);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 8114559e from the openjdk/jfx repository.

The commit being backported was authored by Johan Vos on 4 Mar 2024 and was reviewed by Kevin Rushforth.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327177](https://bugs.openjdk.org/browse/JDK-8327177) needs maintainer approval

### Issue
 * [JDK-8327177](https://bugs.openjdk.org/browse/JDK-8327177): macOS: wrong GlobalRef deleted in GlassMenu (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/184/head:pull/184` \
`$ git checkout pull/184`

Update a local copy of the PR: \
`$ git checkout pull/184` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 184`

View PR using the GUI difftool: \
`$ git pr show -t 184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/184.diff">https://git.openjdk.org/jfx17u/pull/184.diff</a>

</details>
