### PR TITLE
8332328: [GHA] GitHub Actions build fails on Linux: unable to find gcc-13

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -58,7 +58,7 @@ jobs:
   linux_x64_build:
     name: Linux x64
     needs: validation
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     env:
       # FIXME: read this information from a property file


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332328](https://bugs.openjdk.org/browse/JDK-8332328) needs maintainer approval

### Issue
 * [JDK-8332328](https://bugs.openjdk.org/browse/JDK-8332328): [GHA] GitHub Actions build fails on Linux: unable to find gcc-13 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/191/head:pull/191` \
`$ git checkout pull/191`

Update a local copy of the PR: \
`$ git checkout pull/191` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 191`

View PR using the GUI difftool: \
`$ git pr show -t 191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/191.diff">https://git.openjdk.org/jfx17u/pull/191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/191#issuecomment-2147984849)