### PR TITLE
8236689: macOS 10.15 Catalina: LCD text renders badly

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -133,7 +133,7 @@ public abstract class PrismFontFactory implements FontFactory {
                         }
                     }
 
-                    boolean lcdTextOff = isIOS || isAndroid || isEmbedded;
+                    boolean lcdTextOff = isMacOSX || isIOS || isAndroid || isEmbedded;
                     String defLCDProp = lcdTextOff ? "false" : "true";
                     String lcdProp = System.getProperty("prism.lcdtext", defLCDProp);
                     lcdEnabled = lcdProp.equals("true");

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyph.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyph.java
@@ -26,6 +26,7 @@
 package com.sun.javafx.font.coretext;
 
 import com.sun.javafx.font.FontResource;
+import com.sun.javafx.font.PrismFontFactory;
 import com.sun.javafx.font.Glyph;
 import com.sun.javafx.geom.RectBounds;
 import com.sun.javafx.geom.Shape;
@@ -39,7 +40,7 @@ class CTGlyph implements Glyph {
     private boolean drawShapes;
 
     /* Always using BRGA context has the same performance as gray */
-    private static boolean LCD_CONTEXT = true;
+    private static boolean LCD_CONTEXT = PrismFontFactory.getFontFactory().isLCDTextSupported();
     private static boolean CACHE_CONTEXT = true;
 
     private static long cachedContextRef;


### PR DESCRIPTION
Hi all,

This pull request contains a clean backport of commit [a118d333](https://github.com/openjdk/jfx/commit/a118d33314a363336134d31c45b50329594e5a24) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Phil Race on 20 Oct 2021 and was reviewed by Kevin Rushforth and Pankaj Bansal.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8236689](https://bugs.openjdk.org/browse/JDK-8236689) needs maintainer approval

### Issue
 * [JDK-8236689](https://bugs.openjdk.org/browse/JDK-8236689): macOS 10.15 Catalina: LCD text renders badly (**Bug** - P3 - Approved)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/195/head:pull/195` \
`$ git checkout pull/195`

Update a local copy of the PR: \
`$ git checkout pull/195` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 195`

View PR using the GUI difftool: \
`$ git pr show -t 195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/195.diff">https://git.openjdk.org/jfx17u/pull/195.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/195#issuecomment-2202303660)