### PR TITLE
8335548: testCookieEnabled fails with WebKit 619.1

### DIFF
--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -227,9 +227,15 @@ public class MiscellaneousTest extends TestBase {
         }
     }
 
-    @Ignore("JDK-8335548")
-    @Test public void testCookieEnabled() {
+
+    @Test public void testCookieEnabled() throws Exception {
         final WebEngine webEngine = createWebEngine();
+        String location = new File("src/test/resources/test/html/cookie.html")
+                .toURI().toASCIIString().replaceAll("^file:/", "file:///");
+        Platform.runLater(() -> {
+            webEngine.load(location);
+        });
+        Thread.sleep(1000);
         submit(() -> {
             final JSObject window = (JSObject) webEngine.executeScript("window");
             assertNotNull(window);

--- a/modules/javafx.web/src/test/resources/test/html/cookie.html
+++ b/modules/javafx.web/src/test/resources/test/html/cookie.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+test cookie
+</body>
+</html>


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 33d82c04 from the openjdk/jfx repository.

The commit being backported was authored by Jay Bhaskar on 21 Jul 2024 and was reviewed by Kevin Rushforth.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335548](https://bugs.openjdk.org/browse/JDK-8335548) needs maintainer approval

### Issue
 * [JDK-8335548](https://bugs.openjdk.org/browse/JDK-8335548): testCookieEnabled fails with WebKit 619.1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/205.diff">https://git.openjdk.org/jfx17u/pull/205.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/205#issuecomment-2343525789)