### PR TITLE
8315870: icu fails to compile with Visual Studio 2022 17.6.5

### DIFF
--- a/modules/javafx.web/src/main/native/Source/ThirdParty/icu/source/i18n/fmtable.cpp
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/icu/source/i18n/fmtable.cpp
@@ -56,7 +56,7 @@ using number::impl::DecimalQuantity;
 // Return true if *a == *b.
 static inline UBool objectEquals(const UObject* a, const UObject* b) {
     // LATER: return *a == *b;
-    return *((const Measure*) a) == *((const Measure*) b);
+    return *((const Measure*) a) == *b;
 }
 
 // Return a clone of *a.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit ed921717 from the openjdk/jfx repository.

The commit being backported was authored by Kevin Rushforth on 8 Sep 2023 and was reviewed by Ambarish Rapte and Johan Vos.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315870](https://bugs.openjdk.org/browse/JDK-8315870) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8315870: icu fails to compile with Visual Studio 2022 17.6.5`

### Issue
 * [JDK-8315870](https://bugs.openjdk.org/browse/JDK-8315870): icu fails to compile with Visual Studio 2022 17.6.5 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/207/head:pull/207` \
`$ git checkout pull/207`

Update a local copy of the PR: \
`$ git checkout pull/207` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 207`

View PR using the GUI difftool: \
`$ git pr show -t 207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/207.diff">https://git.openjdk.org/jfx17u/pull/207.diff</a>

</details>
