### PR TITLE
8336798: DRT test cssrounding.html test for linear layout fails with WebKit 619.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -191,10 +191,15 @@ inline InlineLayoutUnit InlineLevelBox::preferredLineHeight() const
 {
     if (isPreferredLineHeightFontMetricsBased())
         return primarymetricsOfPrimaryFont().floatLineSpacing();
-
+#if !PLATFORM(JAVA)
     if (m_style.lineHeight.isPercentOrCalculated())
         return minimumValueForLength(m_style.lineHeight, fontSize());
     return m_style.lineHeight.value();
+#else // required to round a floating-point number down to the nearest integer value otherwise it will introduce 1px extra height
+    if (m_style.lineHeight.isPercentOrCalculated())
+        return floorf(minimumValueForLength(m_style.lineHeight, fontSize()));
+    return floorf(m_style.lineHeight.value());
+#endif
 }
 
 inline bool InlineLevelBox::hasLineBoxRelativeAlignment() const

--- a/tests/system/src/test/java/test/javafx/scene/web/CSSRoundingTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/CSSRoundingTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.concurrent.Worker;
+import javafx.scene.Scene;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import test.util.Util;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CSSRoundingTest {
+
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+
+    // Maintain one application instance
+    static CSSRoundingTestApp cssRoundingTestApp;
+    public static Stage primaryStage;
+    public static WebView webView;
+
+    public static class CSSRoundingTestApp extends Application {
+
+        @Override
+        public void init() {
+            CSSRoundingTest.cssRoundingTestApp = this;
+        }
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            CSSRoundingTest.primaryStage = primaryStage;
+            webView = new WebView();
+            Scene scene = new Scene(webView, 150, 100);
+            primaryStage.setScene(scene);
+            primaryStage.show();
+            launchLatch.countDown();
+        }
+    }
+
+    @BeforeAll
+    public static void setupOnce() {
+        Util.launch(launchLatch, CSSRoundingTestApp.class);
+    }
+
+    @AfterAll
+    public static void tearDownOnce() {
+        Util.shutdown();
+    }
+
+    @Test
+    public void testCSSroundingForLinearLayout() {
+
+        final CountDownLatch webViewStateLatch = new CountDownLatch(1);
+
+        Util.runAndWait(() -> {
+            assertNotNull(webView);
+
+            webView.getEngine().getLoadWorker().stateProperty().addListener((observable, oldValue, newValue) -> {
+                if (newValue == Worker.State.SUCCEEDED) {
+                    webView.requestFocus();
+                }
+            });
+
+            webView.focusedProperty().addListener((observable, oldValue, newValue) -> {
+                if (newValue) {
+                    webViewStateLatch.countDown();
+                }
+            });
+
+            String content = """
+                <html>
+                <head>
+                <style type="text/css">
+                    body, div {
+                        margin: 0;
+                        padding: 0;
+                        border: 0;
+                    }
+                    #top, #bottom {
+                        line-height: 1.5;
+                        font-size: 70%;
+                        background:green;
+                        color:white;
+                        width:100%;
+                    }
+                    #top {
+                        padding:.6em 0 .7em;
+                    }
+                    #bottom {
+                      position:absolute;
+                      top:2.8em;
+                    }
+                </style>
+                </head>
+                <body>
+                <div id="top">no gap below</div>
+                <div id="bottom">no gap above</div>
+                <div id="description"></div>
+                <div id="console"></div>
+                <script>
+                description("This test checks that floating point rounding doesn't cause misalignment.  There should be no gap between the divs.");
+                var divtop = document.getElementById("top").getBoundingClientRect();
+                var divbottom = document.getElementById("bottom").getBoundingClientRect();
+                console.log("divtop.bottom: " + divtop.bottom);
+                console.log("divbottom.top: " + divbottom.top);
+                window.testResults = { topBottom: Math.round(divtop.bottom), bottomTop: Math.round(divbottom.top) };
+                </script>
+                </body>
+                </html>
+                """;
+            webView.getEngine().loadContent(content);
+        });
+
+        assertTrue(Util.await(webViewStateLatch), "Timeout when waiting for focus change");
+        // Introduce sleep to ensure web contents are loaded
+        Util.sleep(1000);
+
+        Util.runAndWait(() -> {
+            webView.getEngine().executeScript("""
+                var divtop = document.getElementById("top").getBoundingClientRect();
+                var divbottom = document.getElementById("bottom").getBoundingClientRect();
+                var topBottom = Math.round(divtop.bottom);
+                var bottomTop = Math.round(divbottom.top);
+                window.testResults = { topBottom: topBottom, bottomTop: bottomTop };
+                """);
+
+            int topBottom = ((Number) webView.getEngine().executeScript("window.testResults.topBottom")).intValue();
+            int bottomTop = ((Number) webView.getEngine().executeScript("window.testResults.bottomTop")).intValue();
+
+            assertEquals(31, topBottom);
+            assertEquals(31, bottomTop);
+        });
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 06ac1678 from the openjdk/jfx repository.

The commit being backported was authored by Jay Bhaskar on 22 Jul 2024 and was reviewed by Hima Bindu Meda and Kevin Rushforth.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336798](https://bugs.openjdk.org/browse/JDK-8336798) needs maintainer approval

### Issue
 * [JDK-8336798](https://bugs.openjdk.org/browse/JDK-8336798): DRT test cssrounding.html test for linear layout fails with WebKit 619.1 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/212/head:pull/212` \
`$ git checkout pull/212`

Update a local copy of the PR: \
`$ git checkout pull/212` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 212`

View PR using the GUI difftool: \
`$ git pr show -t 212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/212.diff">https://git.openjdk.org/jfx17u/pull/212.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/212#issuecomment-2490871860)
</details>
