### PR TITLE
8337481: File API: file.name contains path instead of name

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/FileSystemJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/FileSystemJava.cpp
@@ -273,7 +273,7 @@ int readFromFile(PlatformFileHandle handle, void* data, int length)
     return result;
 }
 
-String pathGetFileName(const String& path)
+String pathFileName(const String& path)
 {
     JNIEnv* env = WTF::GetJavaEnv();
 
@@ -439,13 +439,6 @@ bool isHiddenFile(const String& path)
     fprintf(stderr, "isHiddenFile(const String& path) NOT IMPLEMENTED\n");
     UNUSED_PARAM(path);
     return false;
-}
-
-String pathFileName(const String& path)
-{
-    UNUSED_PARAM(path);
-   // return path.substring(path.reverseFind('/') + 1);
-   return nullString();
 }
 
 bool hardLinkOrCopyFile(const String& targetPath, const String& linkPath)

--- a/modules/javafx.web/src/main/native/Source/WebCore/fileapi/File.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/fileapi/File.cpp
@@ -135,12 +135,7 @@ void File::computeNameAndContentType(const String& path, const String& nameOverr
     }
 #endif
 
-#if !PLATFORM(JAVA)
     effectiveName = nameOverride.isEmpty() ? FileSystem::pathFileName(path) : nameOverride;
-#else
-    // Use simple path not from std::FileSystem
-    effectiveName = nameOverride.isEmpty() ? path : nameOverride;
-#endif
     size_t index = effectiveName.reverseFind('.');
     if (index != notFound) {
         callOnMainThreadAndWait([&effectiveContentType, &effectiveName, index] {

--- a/modules/javafx.web/src/main/native/Source/WebCore/fileapi/FileCocoa.mm
+++ b/modules/javafx.web/src/main/native/Source/WebCore/fileapi/FileCocoa.mm
@@ -59,9 +59,9 @@ bool File::shouldReplaceFile(const String& path)
 
 void File::computeNameAndContentTypeForReplacedFile(const String& path, const String& nameOverride, String& effectiveName, String& effectiveContentType)
 {
-    ASSERT(!FileSystem::pathGetFileName(path).endsWith('/')); // Expecting to get a path without trailing slash, even for directories.
+    ASSERT(!FileSystem::pathFileName(path).endsWith('/')); // Expecting to get a path without trailing slash, even for directories.
     effectiveContentType = "application/zip"_s;
-    effectiveName = makeString((nameOverride.isNull() ? FileSystem::pathGetFileName(path) : nameOverride), ".zip"_s);
+    effectiveName = makeString((nameOverride.isNull() ? FileSystem::pathFileName(path) : nameOverride), ".zip"_s);
 }
 
 }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/FileTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/FileTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import java.io.File;
+
+import com.sun.javafx.webkit.UIClientImplShim;
+import com.sun.webkit.WebPage;
+import com.sun.webkit.WebPageShim;
+import javafx.concurrent.Worker.State;
+import javafx.scene.web.WebEngineShim;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FileTest extends TestBase {
+    private final WebPage page = WebEngineShim.getPage(getEngine());
+    private final String[] fileList = { new File("src/test/resources/test/html/HelloWorld.txt").getAbsolutePath() };
+    private final String script = String.format("<script type='text/javascript'>" +
+                                    "var result;" +
+                                    "window.addEventListener('click', (e) => {" +
+                                        "document.getElementById('file').click();" +
+                                    "});" +
+                                    "function readFile()" +
+                                    "{" +
+                                        "file = event.target.files[0];" +
+                                        "result = file.name;" +
+                                    "}" +
+                                    "</script>" +
+                                    "<body> <input type='file' id='file' onchange='readFile()'/> </body>");
+    @Before
+    public void before() {
+        UIClientImplShim.test_setChooseFiles(fileList);
+    }
+
+    private void loadFileReaderTestScript(String testScript) {
+        loadContent(testScript);
+        submit(() -> {
+            // Send a dummy mouse click event at (0,0) to simulate click on file chooser button.
+            WebPageShim.click(page, 0, 0);
+        });
+    }
+
+    @Test
+    public void testFileName() {
+        loadFileReaderTestScript(script);
+        submit(() -> {
+            assertEquals("Unexpected file name received", "HelloWorld.txt", getEngine().executeScript("window.result"));
+        });
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit ca70a07b from the openjdk/jfx repository.

The commit being backported was authored by Oliver Schmidtmer on 30 Aug 2024 and was reviewed by Ambarish Rapte and Hima Bindu Meda.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337481](https://bugs.openjdk.org/browse/JDK-8337481) needs maintainer approval

### Issue
 * [JDK-8337481](https://bugs.openjdk.org/browse/JDK-8337481): File API: file.name contains path instead of name (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/215.diff">https://git.openjdk.org/jfx17u/pull/215.diff</a>

</details>
