### PR TITLE
8343630: Pass AccessControlContext to/from WebKit as opaque object

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
@@ -104,8 +104,10 @@ public abstract class Utilities {
     private static Object fwkInvokeWithContext(final Method method,
                                                final Object instance,
                                                final Object[] args,
-                                               AccessControlContext acc)
+                                               Object accObj)
             throws Throwable {
+
+        AccessControlContext acc = (AccessControlContext) accObj;
 
         final Class<?> clazz = method.getDeclaringClass();
         if (clazz.equals(java.lang.Class.class)) {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
@@ -28,7 +28,6 @@ package com.sun.webkit.dom;
 import com.sun.webkit.Disposer;
 import com.sun.webkit.DisposerRecord;
 import com.sun.webkit.Invoker;
-import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.util.concurrent.atomic.AtomicInteger;
 import netscape.javascript.JSException;
@@ -93,7 +92,7 @@ class JSObject extends netscape.javascript.JSObject {
     }
     private static native void setMemberImpl(long peer, int peer_type,
                                              String name, Object value,
-                                             @SuppressWarnings("removal") AccessControlContext acc);
+                                             Object acc);
 
     @Override
     public void removeMember(String name) throws JSException {
@@ -120,7 +119,7 @@ class JSObject extends netscape.javascript.JSObject {
     }
     private static native void setSlotImpl(long peer, int peer_type,
                                            int index, Object value,
-                                           @SuppressWarnings("removal") AccessControlContext acc);
+                                           Object acc);
 
     @SuppressWarnings("removal")
     @Override
@@ -131,7 +130,7 @@ class JSObject extends netscape.javascript.JSObject {
     }
     private static native Object callImpl(long peer, int peer_type,
                                           String methodName, Object[] args,
-                                          @SuppressWarnings("removal") AccessControlContext acc);
+                                          Object acc);
 
     @Override
     public String toString() {

--- a/modules/javafx.web/src/main/native/Source/WebCore/bridge/jni/jsc/JNIUtilityPrivate.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bridge/jni/jsc/JNIUtilityPrivate.cpp
@@ -324,7 +324,7 @@ jthrowable dispatchJNICall(int count, RootObject*, jobject obj, bool isStatic, J
       env->SetObjectArrayElement(argsArray, i, args[i]);
     jmethodID invokeMethod =
         env->GetStaticMethodID(utilityCls, "fwkInvokeWithContext",
-                               "(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;Ljava/security/AccessControlContext;)Ljava/lang/Object;");
+                               "(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
     jobject r = env->CallStaticObjectMethod(utilityCls, invokeMethod,
                                             rmethod, obj, argsArray,
                                             accessControlContext);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit fffa0fc4 from the openjdk/jfx repository.

The commit being backported was authored by Kevin Rushforth on 8 Nov 2024 and was reviewed by Andy Goryachev and Jay Bhaskar.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343630](https://bugs.openjdk.org/browse/JDK-8343630) needs maintainer approval

### Issue
 * [JDK-8343630](https://bugs.openjdk.org/browse/JDK-8343630): Pass AccessControlContext to/from WebKit as opaque object (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/220/head:pull/220` \
`$ git checkout pull/220`

Update a local copy of the PR: \
`$ git checkout pull/220` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 220`

View PR using the GUI difftool: \
`$ git pr show -t 220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/220.diff">https://git.openjdk.org/jfx17u/pull/220.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/220#issuecomment-2492224343)
</details>
