### PR TITLE
8345870: Failed to compile test/javafx/scene/web/CSSRoundingTest.java after 8336798

### DIFF
--- a/tests/system/src/test/java/test/javafx/scene/web/CSSRoundingTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/CSSRoundingTest.java
@@ -100,47 +100,45 @@ public class CSSRoundingTest {
                 }
             });
 
-            String content = """
-                <html>
-                <head>
-                <style type="text/css">
-                    body, div {
-                        margin: 0;
-                        padding: 0;
-                        border: 0;
-                    }
-                    #top, #bottom {
-                        line-height: 1.5;
-                        font-size: 70%;
-                        background:green;
-                        color:white;
-                        width:100%;
-                    }
-                    #top {
-                        padding:.6em 0 .7em;
-                    }
-                    #bottom {
-                      position:absolute;
-                      top:2.8em;
-                    }
-                </style>
-                </head>
-                <body>
-                <div id="top">no gap below</div>
-                <div id="bottom">no gap above</div>
-                <div id="description"></div>
-                <div id="console"></div>
-                <script>
-                description("This test checks that floating point rounding doesn't cause misalignment.  There should be no gap between the divs.");
-                var divtop = document.getElementById("top").getBoundingClientRect();
-                var divbottom = document.getElementById("bottom").getBoundingClientRect();
-                console.log("divtop.bottom: " + divtop.bottom);
-                console.log("divbottom.top: " + divbottom.top);
-                window.testResults = { topBottom: Math.round(divtop.bottom), bottomTop: Math.round(divbottom.top) };
-                </script>
-                </body>
-                </html>
-                """;
+            String content = "<html>\n" +
+                    "<head>\n" +
+                    "<style type=\"text/css\">\n" +
+                    "    body, div {\n" +
+                    "        margin: 0;\n" +
+                    "        padding: 0;\n" +
+                    "        border: 0;\n" +
+                    "    }\n" +
+                    "    #top, #bottom {\n" +
+                    "        line-height: 1.5;\n" +
+                    "        font-size: 70%;\n" +
+                    "        background:green;\n" +
+                    "        color:white;\n" +
+                    "        width:100%;\n" +
+                    "    }\n" +
+                    "    #top {\n" +
+                    "        padding:.6em 0 .7em;\n" +
+                    "    }\n" +
+                    "    #bottom {\n" +
+                    "      position:absolute;\n" +
+                    "      top:2.8em;\n" +
+                    "    }\n" +
+                    "</style>\n" +
+                    "</head>\n" +
+                    "<body>\n" +
+                    "<div id=\"top\">no gap below</div>\n" +
+                    "<div id=\"bottom\">no gap above</div>\n" +
+                    "<div id=\"description\"></div>\n" +
+                    "<div id=\"console\"></div>\n" +
+                    "<script>\n" +
+                    "description(\"This test checks that floating point rounding doesn't cause misalignment.  There should be no gap between the divs.\");\n" +
+                    "var divtop = document.getElementById(\"top\").getBoundingClientRect();\n" +
+                    "var divbottom = document.getElementById(\"bottom\").getBoundingClientRect();\n" +
+                    "console.log(\"divtop.bottom: \" + divtop.bottom);\n" +
+                    "console.log(\"divbottom.top: \" + divbottom.top);\n" +
+                    "window.testResults = { topBottom: Math.round(divtop.bottom), bottomTop: Math.round(divbottom.top) };\n" +
+                    "</script>\n" +
+                    "</body>\n" +
+                    "</html>\n";
             webView.getEngine().loadContent(content);
         });
 
@@ -149,13 +147,12 @@ public class CSSRoundingTest {
         Util.sleep(1000);
 
         Util.runAndWait(() -> {
-            webView.getEngine().executeScript("""
-                var divtop = document.getElementById("top").getBoundingClientRect();
-                var divbottom = document.getElementById("bottom").getBoundingClientRect();
-                var topBottom = Math.round(divtop.bottom);
-                var bottomTop = Math.round(divbottom.top);
-                window.testResults = { topBottom: topBottom, bottomTop: bottomTop };
-                """);
+            webView.getEngine().executeScript(
+                    "var divtop = document.getElementById(\"top\").getBoundingClientRect();\n" +
+                    "var divbottom = document.getElementById(\"bottom\").getBoundingClientRect();\n" +
+                    "var topBottom = Math.round(divtop.bottom);\n" +
+                    "var bottomTop = Math.round(divbottom.top);\n" +
+                    "window.testResults = { topBottom: topBottom, bottomTop: bottomTop };\n");
 
             int topBottom = ((Number) webView.getEngine().executeScript("window.testResults.topBottom")).intValue();
             int bottomTop = ((Number) webView.getEngine().executeScript("window.testResults.bottomTop")).intValue();


### PR DESCRIPTION
Hi,

this PR fixes the build failure after backporting JDK-8336798 [1].
The test CSSRoundingTest.java uses multiline string literals, that are not supported with -source 11.


[1] https://bugs.openjdk.org/browse/JDK-8336798

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345870](https://bugs.openjdk.org/browse/JDK-8345870) needs maintainer approval

### Issue
 * [JDK-8345870](https://bugs.openjdk.org/browse/JDK-8345870): Failed to compile test/javafx/scene/web/CSSRoundingTest.java after 8336798 (**Bug** - P4 - Approved)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/221.diff">https://git.openjdk.org/jfx17u/pull/221.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/221#issuecomment-2531002971)
</details>
