### PR TITLE
Merge 509b8695024b6d1e26bbb0360a41365bf19ac3e9

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/dshowwrapper.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/dshowwrapper.cpp
@@ -2007,7 +2007,7 @@ static gboolean dshowwrapper_load_decoder_h264(GstStructure *s, GstDShowWrapper 
             if (gst_buffer_map(codec_data, &info, GST_MAP_READ))
             {
                 if (info.size <= MAX_HEADER_SIZE)
-                    header_size = (gint)dshowwrapper_get_avc_config(codec_data_info.data, codec_data_info.size, header, MAX_HEADER_SIZE, &decoder->lengthSizeMinusOne);
+                    header_size = (gint)dshowwrapper_get_avc_config(info.data, info.size, header, 256, &avcProfile, &avcLevel, &lengthSizeMinusOne);
                 gst_buffer_unmap(codec_data, &info);
             }
         }


### PR DESCRIPTION
The patch for dshowwrapper for 17u requires one different line compared to the one for 21u. I accidentally pushed the wrong branch first. This PR fixes that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/223/head:pull/223` \
`$ git checkout pull/223`

Update a local copy of the PR: \
`$ git checkout pull/223` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 223`

View PR using the GUI difftool: \
`$ git pr show -t 223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/223.diff">https://git.openjdk.org/jfx17u/pull/223.diff</a>

</details>
