### PR TITLE
8348318: Change JavaFX release version to 17.0.15 in jfx17u 

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=jfx17.0.14
+version=jfx17.0.15
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -41,7 +41,7 @@ jfx.release.suffix=-ea
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
 jfx.release.major.version=17
 jfx.release.minor.version=0
-jfx.release.security.version=14
+jfx.release.security.version=15
 jfx.release.patch.version=0
 
 # Note: The release version is now calculated in build.gradle as the


### PR DESCRIPTION
Bump version to 17.0.15

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8348318](https://bugs.openjdk.org/browse/JDK-8348318) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348318](https://bugs.openjdk.org/browse/JDK-8348318): Change JavaFX release version to 17.0.15 in jfx17u (**Task** - P2 - Approved)


### Reviewers
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/224.diff">https://git.openjdk.org/jfx17u/pull/224.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/224#issuecomment-2608156347)
</details>
