### PR TITLE
8323880: Caret rendered at wrong position in case of a click event on RTL text

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/FontCascade.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/FontCascade.h
@@ -316,7 +316,19 @@ private:
 
     bool advancedTextRenderingMode() const
     {
+#if !PLATFORM(JAVA)
         return m_fontDescription.textRenderingMode() != TextRenderingMode::OptimizeSpeed;
+#else
+        //The current implementation of complex text rendering path on the Java platform is experiencing
+        //side effects. We need to align with WebKit 616.1 standards.
+        auto textRenderingMode = m_fontDescription.textRenderingMode();
+        if (textRenderingMode == TextRenderingMode::GeometricPrecision || textRenderingMode == TextRenderingMode::OptimizeLegibility)
+            return true;
+        if (textRenderingMode == TextRenderingMode::OptimizeSpeed)
+            return false;
+
+        return false;
+#endif
     }
 
     bool computeEnableKerning() const


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1fb56e33](https://github.com/openjdk/jfx/commit/1fb56e333bc65860cc1abeebd1cbb01cd8b8e5f3) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Jay Bhaskar on 16 Feb 2024 and was reviewed by Kevin Rushforth and Hima Bindu Meda.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323880](https://bugs.openjdk.org/browse/JDK-8323880) needs maintainer approval

### Issue
 * [JDK-8323880](https://bugs.openjdk.org/browse/JDK-8323880): Caret rendered at wrong position in case of a click event on RTL text (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/228/head:pull/228` \
`$ git checkout pull/228`

Update a local copy of the PR: \
`$ git checkout pull/228` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 228`

View PR using the GUI difftool: \
`$ git pr show -t 228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/228.diff">https://git.openjdk.org/jfx17u/pull/228.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/228#issuecomment-2700051480)
</details>
