### PR TITLE
8154847: Rendering is incorrect or not visible with StageStyle.UNIFIED on some graphics cards

### DIFF
--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DResourceManager.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DResourceManager.cc
@@ -557,6 +557,7 @@ D3DResourceManager::CreateSwapChain(HWND hWnd, UINT numBuffers,
     newParams.Windowed = TRUE;
     newParams.BackBufferCount = numBuffers;
     newParams.SwapEffect = swapEffect;
+    newParams.BackBufferFormat = D3DFMT_A8R8G8B8;
     newParams.PresentationInterval = presentationInterval;
 
     IDirect3DSwapChain9 *pSwapChain = NULL;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [28bde153](https://github.com/openjdk/jfx/commit/28bde153cbf960e1b8d74d258ba351a5305f124b) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Christopher Schnick on 5 Feb 2026 and was reviewed by Lukasz Kostyra and Kevin Rushforth.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8154847](https://bugs.openjdk.org/browse/JDK-8154847) needs maintainer approval

### Issue
 * [JDK-8154847](https://bugs.openjdk.org/browse/JDK-8154847): Rendering is incorrect or not visible with StageStyle.UNIFIED on some graphics cards (**Bug** - P3 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/251/head:pull/251` \
`$ git checkout pull/251`

Update a local copy of the PR: \
`$ git checkout pull/251` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 251`

View PR using the GUI difftool: \
`$ git pr show -t 251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/251.diff">https://git.openjdk.org/jfx17u/pull/251.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/251#issuecomment-3870923586)
</details>
