### PR TITLE
8379211: Uninitialised memory in Java_com_sun_javafx_font_freetype_OSFreetype_FT_1Outline_1Decompose

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/freetype.c
+++ b/modules/javafx.graphics/src/main/native-font/freetype.c
@@ -618,7 +618,10 @@ JNIEXPORT jobject JNICALL OS_NATIVE(FT_1Outline_1Decompose)
     data.pointTypes = (jbyte*)malloc(sizeof(jbyte) * DEFAULT_LEN_TYPES);
     data.numTypes = 0;
     data.lenTypes = DEFAULT_LEN_TYPES;
-    if (data.pointTypes == NULL) goto fail;
+    if (data.pointTypes == NULL) {
+        data.pointCoords = NULL;
+        goto fail;
+    }
 
     data.pointCoords = (jfloat*)malloc(sizeof(jfloat) * DEFAULT_LEN_COORDS);
     data.numCoords = 0;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 8d1a946d from the openjdk/jfx repository.

The commit being backported was authored by Kevin Rushforth on 1 Apr 2026 and was reviewed by Lukasz Kostyra and Ambarish Rapte.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8379211](https://bugs.openjdk.org/browse/JDK-8379211) needs maintainer approval

### Issue
 * [JDK-8379211](https://bugs.openjdk.org/browse/JDK-8379211): Uninitialised memory in Java_com_sun_javafx_font_freetype_OSFreetype_FT_1Outline_1Decompose (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/268/head:pull/268` \
`$ git checkout pull/268`

Update a local copy of the PR: \
`$ git checkout pull/268` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 268`

View PR using the GUI difftool: \
`$ git pr show -t 268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/268.diff">https://git.openjdk.org/jfx17u/pull/268.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/268#issuecomment-4594705382)
</details>
