### PR TITLE
8329874: JavaFX debug builds fail on Linux

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/CMakeLists.txt
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/CMakeLists.txt
@@ -1539,7 +1539,8 @@ if (CMAKE_COMPILER_IS_GNUCXX AND GCC_OFFLINEASM_SOURCE_MAP)
             FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ GROUP_WRITE GROUP_READ WORLD_READ
             DESTINATION ${JavaScriptCore_SCRIPTS_DIR}
         )
-        set(LowLevelInterpreter_LAUNCHER "${RUBY_EXECUTABLE} ${JavaScriptCore_SCRIPTS_SOURCES_DIR}/postprocess-asm")
+        #use copy not actual source
+        set(LowLevelInterpreter_LAUNCHER "${RUBY_EXECUTABLE} ${JavaScriptCore_SCRIPTS_DIR}/postprocess-asm")
     else ()
     set(LowLevelInterpreter_LAUNCHER "${RUBY_EXECUTABLE} ${JavaScriptCore_SCRIPTS_SOURCES_DIR}/postprocess-asm")
     endif ()

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/RefCounted.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/RefCounted.h
@@ -90,7 +90,7 @@ public:
 protected:
     RefCountedBase()
         : m_refCount(1)
-#if ASSERT_ENABLED
+#if ASSERT_ENABLED && !PLATFORM(JAVA)
         , m_isOwnedByMainThread(isMainThread())
 #endif
     {
@@ -107,7 +107,7 @@ protected:
 
     void applyRefDerefThreadingCheck() const
     {
-#if ASSERT_ENABLED
+#if ASSERT_ENABLED && !PLATFORM(JAVA)
         if (m_refCount == 1) {
             // Likely an ownership transfer across threads that may be safe.
             m_isOwnedByMainThread = isMainThread();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 35c1e39c from the openjdk/jfx repository.

The commit being backported was authored by Jay Bhaskar on 17 Sep 2025 and was reviewed by Kevin Rushforth and Hima Bindu Meda.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8329874](https://bugs.openjdk.org/browse/JDK-8329874) needs maintainer approval

### Issue
 * [JDK-8329874](https://bugs.openjdk.org/browse/JDK-8329874): JavaFX debug builds fail on Linux (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/279/head:pull/279` \
`$ git checkout pull/279`

Update a local copy of the PR: \
`$ git checkout pull/279` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 279`

View PR using the GUI difftool: \
`$ git pr show -t 279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/279.diff">https://git.openjdk.org/jfx17u/pull/279.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/279#issuecomment-5325205589)
</details>
