### PR TITLE
8387337: GlassClipboard: Replace deprecated hash_map and hash_set

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
 
 #include "common.h"
 
-#define  _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
-#include <hash_map>
-#include <hash_set>
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
 
 // The following is derived from _HASH_SEED, which is an internal constant from
 // include/xhash; since this is an internal constant we define our own rather
@@ -79,18 +79,22 @@ bool operator == (const FORMATETC &fr, const FORMATETC &fl) {
          && fr.tymed    == fl.tymed;
 }
 
-size_t hash_value(const FORMATETC &fr)
+template<>
+struct std::hash<FORMATETC>
 {
-    size_t _Val = size_t(fr.cfFormat) << 21;
-    _Val += size_t(fr.dwAspect);
-    _Val <<= 5;
-    _Val += size_t(fr.lindex);
-    _Val <<= 7;
-    _Val += size_t(fr.ptd);
-    _Val >>= 13;
-    _Val += size_t(fr.tymed);
-    return _Val ^ GLASS_HASH_SEED;
-}
+    std::size_t operator()(const FORMATETC& fr) const noexcept
+    {
+        size_t _Val = size_t(fr.cfFormat) << 21;
+        _Val += size_t(fr.dwAspect);
+        _Val <<= 5;
+        _Val += size_t(fr.lindex);
+        _Val <<= 7;
+        _Val += size_t(fr.ptd);
+        _Val >>= 13;
+        _Val += size_t(fr.tymed);
+        return _Val ^ GLASS_HASH_SEED;
+    }
+};
 
 //NB! There are two suffixes for mimes:
 // ";locale" - the ASCII/UTF8 version of mime type that is not transferred to Java
@@ -138,16 +142,21 @@ Mime2oscfstrPair pairs[] = {
     {MS_FILE_CONTENT, CFSTR_FILECONTENTS},
 };
 
-inline size_t hash_value(const _bstr_t &_Str) {
-    return stdext::hash_value((const wchar_t *)_Str);
-}
+template<>
+struct std::hash<_bstr_t>
+{
+    std::size_t operator()(const _bstr_t& k) const noexcept
+    {
+        // TODO It would be faster to use wstring_view here, but it is in C++17 and above
+        return std::hash<std::wstring>()(std::wstring(static_cast<const wchar_t*>(k)));
+    }
+};
 
-
-typedef stdext::hash_map<_bstr_t, CLIPFORMAT> MIME2OSCF;
-typedef stdext::hash_map<CLIPFORMAT, _bstr_t> OSCF2MIME;
-typedef stdext::hash_map<FORMATETC, _bstr_t> FMC2MIME;
-typedef stdext::hash_map<FORMATETC, STGMEDIUM> FMC2DATA;
-typedef stdext::hash_set<_bstr_t> HASH_STR_SET;
+typedef std::unordered_map<_bstr_t, CLIPFORMAT> MIME2OSCF;
+typedef std::unordered_map<CLIPFORMAT, _bstr_t> OSCF2MIME;
+typedef std::unordered_map<FORMATETC, _bstr_t> FMC2MIME;
+typedef std::unordered_map<FORMATETC, STGMEDIUM> FMC2DATA;
+typedef std::unordered_set<_bstr_t> HASH_STR_SET;
 
 MIME2OSCF mime2oscf;
 OSCF2MIME oscf2mime;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 97525592 from the openjdk/jfx repository.

The commit being backported was authored by Lukasz Kostyra on 7 Jul 2026 and was reviewed by Kevin Rushforth and Ambarish Rapte.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8387337](https://bugs.openjdk.org/browse/JDK-8387337) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387337](https://bugs.openjdk.org/browse/JDK-8387337): GlassClipboard: Replace deprecated hash_map and hash_set (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx17u.git pull/288/head:pull/288` \
`$ git checkout pull/288`

Update a local copy of the PR: \
`$ git checkout pull/288` \
`$ git pull https://git.openjdk.org/jfx17u.git pull/288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 288`

View PR using the GUI difftool: \
`$ git pr show -t 288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx17u/pull/288.diff">https://git.openjdk.org/jfx17u/pull/288.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx17u/pull/288#issuecomment-5356701503)
</details>
